### PR TITLE
Add domain models, configure DbContext, and add NUnit test project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,201 @@
+# editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+# Specify UTF-8 without byte-order mark
+[*.{csproj,locproj,nativeproj,proj,resx,slnx,vbproj}]
+charset = utf-8
+
+# Generated code
+[*{_AssemblyInfo.cs,.notsupported.cs,AsmOffsets.cs}]
+generated_code = true
+
+# C# files
+[*.cs]
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async:suggestion
+
+# avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Types: use keywords instead of BCL types, and permit var only when the type is clear
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_elsewhere = false:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds   = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# static fields should have s_ prefix
+dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_have_prefix.style    = static_prefix_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
+dotnet_naming_style.static_prefix_style.required_prefix = s_
+dotnet_naming_style.static_prefix_style.capitalization = camel_case
+
+# internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
+
+# Code style defaults
+csharp_using_directive_placement = outside_namespace:suggestion
+dotnet_sort_system_directives_first = true
+csharp_prefer_braces = true:silent
+csharp_preserve_single_line_blocks = true:none
+csharp_preserve_single_line_statements = false:none
+csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_simple_using_statement = false:none
+csharp_style_prefer_switch_expression = true:suggestion
+dotnet_style_readonly_field = true:suggestion
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_collection_expression = when_types_exactly_match
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+csharp_prefer_simple_default_expression = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = true:silent
+csharp_style_expression_bodied_constructors = true:silent
+csharp_style_expression_bodied_operators = true:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = true:silent
+
+# Pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# Null checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Other features
+csharp_style_prefer_index_operator = false:none
+csharp_style_prefer_range_operator = false:none
+csharp_style_pattern_local_over_anonymous_function = false:none
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# License header
+file_header_template = 
+
+[src/libraries/System.Net.Http/src/System/Net/Http/{SocketsHttpHandler/Http3RequestStream.cs,BrowserHttpHandler/BrowserHttpHandler.cs}]
+# disable CA2025, the analyzer throws a NullReferenceException when processing this file: https://github.com/dotnet/roslyn-analyzers/issues/7652
+dotnet_diagnostic.CA2025.severity = none
+
+# C++ Files
+[*.{cpp,h,in}]
+curly_bracket_next_line = true
+indent_brace_style = Allman
+
+# Xml project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
+indent_size = 2
+
+# Xml build files
+[*.builds]
+indent_size = 2
+
+# Xml files
+[*.{resx,ruleset,slnx,stylecop,xml}]
+indent_size = 2
+
+# Xml resource files
+[*.resx]
+# match Visual Studio behavior
+insert_final_newline = false
+trim_trailing_whitespace = false
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
+indent_size = 2
+
+# Data serialization
+[*.{json,yaml,yml}]
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+end_of_line = lf
+[*.{cmd,bat}]
+end_of_line = crlf

--- a/GardaVettingSystem.Tests/GardaVettingSystem.Tests.csproj
+++ b/GardaVettingSystem.Tests/GardaVettingSystem.Tests.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+	  <!-- CA1707: underscores in test names -->
+	  <NoWarn>$(NoWarn);CA1707</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.7.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GardaVettingSystem\GardaVettingSystem.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+</Project>

--- a/GardaVettingSystem.Tests/Models/ApplicantTests.cs
+++ b/GardaVettingSystem.Tests/Models/ApplicantTests.cs
@@ -1,0 +1,33 @@
+﻿using GardaVettingSystem.Models;
+
+namespace GardaVettingSystem.Tests.Models
+{
+    public class ApplicantTests
+    {
+        [Test]
+        public void Applicant_FullName_ReturnsFirstAndLastName()
+        {
+            // Arrange
+            var applicant = new Applicant
+            {
+                FirstName = "Ann Marie",
+                LastName = "Dunne"
+            };
+
+            // Assert
+            Assert.That(applicant.FullName, Is.EqualTo("Ann Marie Dunne"));
+        }
+
+        [Test]
+        public void Applicant_DefaultValues_AreNotNull()
+        {
+            // Arrange
+            var applicant = new Applicant();
+
+            // Assert
+            Assert.That(applicant.FirstName, Is.EqualTo(string.Empty));
+            Assert.That(applicant.LastName, Is.EqualTo(string.Empty));
+            Assert.That(applicant.UserId, Is.EqualTo(string.Empty));
+        }
+    }
+}

--- a/GardaVettingSystem/Data/ApplicationDbContext.cs
+++ b/GardaVettingSystem/Data/ApplicationDbContext.cs
@@ -1,9 +1,0 @@
-﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore;
-
-namespace GardaVettingSystem.Data
-{
-    public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : IdentityDbContext(options)
-    {
-    }
-}

--- a/GardaVettingSystem/Data/GardaVettingSystemDbContext.cs
+++ b/GardaVettingSystem/Data/GardaVettingSystemDbContext.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using GardaVettingSystem.Models;
+
+namespace GardaVettingSystem.Data
+{
+    public class GardaVettingSystemDbContext(DbContextOptions<GardaVettingSystemDbContext> options) : IdentityDbContext(options)
+    {
+        public DbSet<Applicant> Applicants { get; set; }
+        public DbSet<ApplicantAddress> ApplicantAddresses { get; set; }
+        public DbSet<AccessCode> AccessCodes { get; set; }
+    }
+}

--- a/GardaVettingSystem/Data/Migrations/00000000000000_CreateIdentitySchema.Designer.cs
+++ b/GardaVettingSystem/Data/Migrations/00000000000000_CreateIdentitySchema.Designer.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GardaVettingSystem.Data.Migrations
 {
-    [DbContext(typeof(ApplicationDbContext))]
+    [DbContext(typeof(GardaVettingSystemDbContext))]
     [Migration("00000000000000_CreateIdentitySchema")]
     partial class CreateIdentitySchema
     {

--- a/GardaVettingSystem/Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/GardaVettingSystem/Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GardaVettingSystem.Data.Migrations
 {
-    [DbContext(typeof(ApplicationDbContext))]
+    [DbContext(typeof(GardaVettingSystemDbContext))]
     partial class ApplicationDbContextModelSnapshot : ModelSnapshot
     {
         protected override void BuildModel(ModelBuilder modelBuilder)

--- a/GardaVettingSystem/GardaVettingSystem.csproj
+++ b/GardaVettingSystem/GardaVettingSystem.csproj
@@ -9,10 +9,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
   </ItemGroup>
 
 </Project>

--- a/GardaVettingSystem/GardaVettingSystem.slnx
+++ b/GardaVettingSystem/GardaVettingSystem.slnx
@@ -1,3 +1,4 @@
 <Solution>
+  <Project Path="../GardaVettingSystem.Tests/GardaVettingSystem.Tests.csproj" Id="f5459a2d-95c4-4e1a-9a35-b002e01ac8e9" />
   <Project Path="GardaVettingSystem.csproj" />
 </Solution>

--- a/GardaVettingSystem/Models/AccessCode.cs
+++ b/GardaVettingSystem/Models/AccessCode.cs
@@ -1,0 +1,37 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace GardaVettingSystem.Models
+{
+    public class AccessCode
+    {
+        [Key]
+        public int AccessCodeId { get; set; }
+
+        // Foreign key back to Applicant
+        [ForeignKey("Applicant")]
+        public int ApplicantNumber { get; set; }
+
+        [Required]
+        [StringLength(20, ErrorMessage = "Code cannot exceed 20 characters")]
+        [Display(Name = "Access Code")]
+        public string Code { get; set; } = string.Empty;
+
+        [Required]
+        [StringLength(100, ErrorMessage = "Organisation name cannot exceed 100 characters")]
+        [Display(Name = "Organisation Name")]
+        public string OrganisationName { get; set; } = string.Empty;
+
+        [Display(Name = "Created Date")]
+        public DateTimeOffset CreatedDate { get; set; } = DateTimeOffset.UtcNow;
+
+        [Display(Name = "Expiry Date")]
+        public DateTimeOffset? ExpiryDate { get; set; }
+
+        [Display(Name = "Active")]
+        public bool IsActive { get; set; } = true;
+
+        // Navigation property back to Applicant
+        public Applicant? Applicant { get; set; }
+    }
+}

--- a/GardaVettingSystem/Models/Applicant.cs
+++ b/GardaVettingSystem/Models/Applicant.cs
@@ -1,0 +1,47 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace GardaVettingSystem.Models
+{
+    public class Applicant
+    {
+        // Primary key - auto-generated applicant number
+        [Key]
+        public int ApplicantNumber { get; set; }
+
+        public string UserId { get; set; } = string.Empty;
+
+        // Member's first and last name stored separately
+        [Required(ErrorMessage = "First name is required")]
+        [StringLength(50, ErrorMessage = "First name cannot exceed 50 characters")]
+        [Display(Name = "First Name")]
+        public string FirstName { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Last name is required")]
+        [StringLength(50, ErrorMessage = "Last name cannot exceed 50 characters")]
+        [Display(Name = "Last Name")]
+        public string LastName { get; set; } = string.Empty;
+
+        public string FullName => $"{FirstName} {LastName}";
+
+        [StringLength(50, ErrorMessage = "Birth surname name cannot exceed 50 characters")]
+        [Display(Name = "Surname name at birth")]
+        public string BirthLastName { get; set; } = string.Empty;
+
+        [StringLength(50, ErrorMessage = "Mother's last name cannot exceed 50 characters")]
+        [Display(Name = "Mother's last name")]
+        public string MothersLastName { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Gender is required")]
+        public string Gender { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Date of Birth is required")]
+        public DateTimeOffset? DateOfBirth { get; set; }
+
+        [StringLength(50, ErrorMessage = "Birth place cannot exceed 50 characters")]
+        [Display(Name = "Place of birth")]
+        public string BirthPlace { get; set; } = string.Empty;
+
+
+    }
+
+}

--- a/GardaVettingSystem/Models/ApplicantAddress.cs
+++ b/GardaVettingSystem/Models/ApplicantAddress.cs
@@ -1,0 +1,41 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace GardaVettingSystem.Models
+{
+    public class ApplicantAddress
+    {
+
+        [Key]
+        public int AddressId { get; set; }
+
+        // Foreign key back to Applicant
+        [ForeignKey("Applicant")]
+        public int ApplicantNumber { get; set; }
+
+        [Required(ErrorMessage = "Address is required")]
+        [StringLength(250, ErrorMessage = "Address cannot exceed 250 characters")]
+        [Display(Name = "Address")]
+        public string AddressLine { get; set; } = string.Empty;
+
+        [StringLength(10, ErrorMessage = "Postcode/Eircode cannot exceed 10 characters")]
+        [Display(Name = "Postcode/Eircode")]
+        public string Postcode { get; set; } = string.Empty;
+
+        [StringLength(50, ErrorMessage = "Country cannot exceed 50 characters")]
+        public string Country { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Resident from year is required")]
+        [Display(Name = "Resident From")]
+        public int ResidentFrom { get; set; }
+
+        // Null means this is the current address
+        [Display(Name = "Resident To")]
+        public int? ResidentTo { get; set; }
+
+        // Navigation property back to Applicant
+        public Applicant? Applicant { get; set; }
+
+    }
+
+}

--- a/GardaVettingSystem/Program.cs
+++ b/GardaVettingSystem/Program.cs
@@ -6,12 +6,12 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection") ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
-builder.Services.AddDbContext<ApplicationDbContext>(options =>
+builder.Services.AddDbContext<GardaVettingSystemDbContext>(options =>
     options.UseSqlServer(connectionString));
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 
 builder.Services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = true)
-    .AddEntityFrameworkStores<ApplicationDbContext>();
+    .AddEntityFrameworkStores<GardaVettingSystemDbContext>();
 builder.Services.AddRazorPages();
 
 var app = builder.Build();
@@ -38,4 +38,4 @@ app.MapStaticAssets();
 app.MapRazorPages()
    .WithStaticAssets();
 
-app.Run();
+await app.RunAsync();

--- a/GardaVettingSystem/appsettings.json
+++ b/GardaVettingSystem/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnet-GardaVettingSystem-f936ba6b-6daa-4ca5-b483-1e9b48af8b50;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=GardaVettingSystem;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
## Changes
- Added three domain model classes: Applicant, ApplicantAddress, AccessCode
- Renamed ApplicationDbContext to GardaVettingSystemDbContext
- Registered all three models as DbSets in GardaVettingSystemDbContext
- Added .editorconfig at solution root level
- Added GardaVettingSystem.Tests NUnit project with project reference
- Added initial ApplicantTests covering FullName computed property and default values

## Notes
- DateTimeOffset used for date fields instead of DateTime for locale/timezone independence
- Postcode used instead of Eircode to accommodate international addresses
- All tests passing ✅