### PR TITLE
Separate build and test into distinct CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,14 +65,8 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
 
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: build-output
-          path: GardaVettingSystem
-
       - name: Run tests
-        run: dotnet test --no-build --configuration Release --verbosity normal --logger "trx;LogFileName=test-results.trx"
+        run: dotnet test --configuration Release --verbosity normal --logger "trx;LogFileName=test-results.trx"
 
       - name: Upload test results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Updated the CI workflow to separate build and test into two distinct jobs. 
The test job depends on the build job completing successfully, so if the build fails the tests are skipped automatically. 
This makes it easier to see exactly where a failure occurs in the Actions tab.