### PR TITLE
Implementing ApplicantAddresses 

### DIFF
--- a/GardaVettingSystem.Tests/Models/ApplicantAddressTests.cs
+++ b/GardaVettingSystem.Tests/Models/ApplicantAddressTests.cs
@@ -1,17 +1,169 @@
 ﻿using GardaVettingSystem.Models;
+using System.ComponentModel.DataAnnotations;
 
 namespace GardaVettingSystem.Tests.Models
 {
     public class ApplicantAddressTests
     {
-        [Test]
-        public void ApplicantAddress_DefaultValues_AreCorrect()
-        {
-            // Arrange
-            var address = new ApplicantAddress();
+        private ApplicantAddress _address = default!;
 
-            // Assert
+        [SetUp]
+        public void SetUp()
+        {
+            _address = new ApplicantAddress
+            {
+                AddressLine = "123 Main Street",
+                Postcode = "D01 AB12",
+                Country = "Ireland",
+                ResidentFrom = 2020,
+                ResidentTo = null,
+                ApplicantNumber = 1
+            };
+        }
+
+        // --- Default Values ---
+
+        [Test]
+        public void ApplicantAddress_DefaultValues_AddressLine_IsEmpty()
+        {
+            var address = new ApplicantAddress();
             Assert.That(address.AddressLine, Is.EqualTo(string.Empty));
+        }
+
+        [Test]
+        public void ApplicantAddress_DefaultValues_Postcode_IsEmpty()
+        {
+            var address = new ApplicantAddress();
+            Assert.That(address.Postcode, Is.EqualTo(string.Empty));
+        }
+
+        [Test]
+        public void ApplicantAddress_DefaultValues_Country_IsEmpty()
+        {
+            var address = new ApplicantAddress();
+            Assert.That(address.Country, Is.EqualTo(string.Empty));
+        }
+
+        [Test]
+        public void ApplicantAddress_DefaultValues_ResidentTo_IsNull()
+        {
+            var address = new ApplicantAddress();
+            Assert.That(address.ResidentTo, Is.Null);
+        }
+
+        // --- Valid Model ---
+
+        [Test]
+        public void ApplicantAddress_ValidModel_PassesValidation()
+        {
+            var results = new List<ValidationResult>();
+            var isValid = Validator.TryValidateObject(_address, new ValidationContext(_address), results, true);
+            Assert.That(isValid, Is.True);
+        }
+
+        // --- AddressLine ---
+
+        [Test]
+        public void ApplicantAddress_AddressLine_Required_FailsWhenEmpty()
+        {
+            _address.AddressLine = string.Empty;
+            var results = new List<ValidationResult>();
+            Validator.TryValidateObject(_address, new ValidationContext(_address), results, true);
+            Assert.That(results, Has.Some.Matches<ValidationResult>(r =>
+                r.MemberNames.Contains("AddressLine")));
+        }
+
+        [Test]
+        public void ApplicantAddress_AddressLine_ExceedsMaxLength_FailsValidation()
+        {
+            _address.AddressLine = new string('A', 251);
+            var results = new List<ValidationResult>();
+            Validator.TryValidateObject(_address, new ValidationContext(_address), results, true);
+            Assert.That(results, Has.Some.Matches<ValidationResult>(r =>
+                r.MemberNames.Contains("AddressLine")));
+        }
+
+        [Test]
+        public void ApplicantAddress_AddressLine_AtMaxLength_PassesValidation()
+        {
+            _address.AddressLine = new string('A', 250);
+            var results = new List<ValidationResult>();
+            var isValid = Validator.TryValidateObject(_address, new ValidationContext(_address), results, true);
+            Assert.That(isValid, Is.True);
+        }
+
+        // --- Postcode ---
+
+        [Test]
+        public void ApplicantAddress_Postcode_ExceedsMaxLength_FailsValidation()
+        {
+            _address.Postcode = new string('A', 11);
+            var results = new List<ValidationResult>();
+            Validator.TryValidateObject(_address, new ValidationContext(_address), results, true);
+            Assert.That(results, Has.Some.Matches<ValidationResult>(r =>
+                r.MemberNames.Contains("Postcode")));
+        }
+
+        [Test]
+        public void ApplicantAddress_Postcode_IsOptional_PassesValidationWhenEmpty()
+        {
+            _address.Postcode = string.Empty;
+            var results = new List<ValidationResult>();
+            var isValid = Validator.TryValidateObject(_address, new ValidationContext(_address), results, true);
+            Assert.That(isValid, Is.True);
+        }
+
+        // --- Country ---
+
+        [Test]
+        public void ApplicantAddress_Country_ExceedsMaxLength_FailsValidation()
+        {
+            _address.Country = new string('A', 51);
+            var results = new List<ValidationResult>();
+            Validator.TryValidateObject(_address, new ValidationContext(_address), results, true);
+            Assert.That(results, Has.Some.Matches<ValidationResult>(r =>
+                r.MemberNames.Contains("Country")));
+        }
+
+        [Test]
+        public void ApplicantAddress_Country_IsOptional_PassesValidationWhenEmpty()
+        {
+            _address.Country = string.Empty;
+            var results = new List<ValidationResult>();
+            var isValid = Validator.TryValidateObject(_address, new ValidationContext(_address), results, true);
+            Assert.That(isValid, Is.True);
+        }
+
+        // --- ResidentFrom ---
+
+        [Test]
+        public void ApplicantAddress_ResidentFrom_IsSet_ReturnsCorrectValue()
+        {
+            Assert.That(_address.ResidentFrom, Is.EqualTo(2020));
+        }
+
+        // --- ResidentTo ---
+
+        [Test]
+        public void ApplicantAddress_ResidentTo_WhenNull_IndicatesCurrentAddress()
+        {
+            _address.ResidentTo = null;
+            Assert.That(_address.ResidentTo, Is.Null);
+        }
+
+        [Test]
+        public void ApplicantAddress_ResidentTo_WhenSet_StoresCorrectYear()
+        {
+            _address.ResidentTo = 2022;
+            Assert.That(_address.ResidentTo, Is.EqualTo(2022));
+        }
+
+        // --- Foreign Key ---
+
+        [Test]
+        public void ApplicantAddress_ApplicantNumber_IsSet_ReturnsCorrectValue()
+        {
+            Assert.That(_address.ApplicantNumber, Is.EqualTo(1));
         }
     }
 }

--- a/GardaVettingSystem.Tests/Models/ApplicantTests.cs
+++ b/GardaVettingSystem.Tests/Models/ApplicantTests.cs
@@ -1,167 +1,287 @@
 ﻿using GardaVettingSystem.Models;
+using System.ComponentModel.DataAnnotations;
 
 namespace GardaVettingSystem.Tests.Models
 {
     public class ApplicantTests
     {
-        [Test]
-        public void Applicant_FullName_ReturnsFirstAndLastName()
-        {
-            // Arrange
-            var applicant = new Applicant
-            {
-                FirstName = "Joe",
-                LastName = "Bloggs"
-            };
+        private Applicant _applicant = default!;
 
-            // Assert
-            Assert.That(applicant.FullName, Is.EqualTo("Joe Bloggs"));
+        [SetUp]
+        public void SetUp()
+        {
+            _applicant = new Applicant
+            {
+                ApplicantNumber = 1,
+                UserId = "abc-123-def-456",
+                FirstName = "Joe",
+                LastName = "Bloggs",
+                BirthLastName = "Smith",
+                MothersLastName = "Smith",
+                Gender = "Male",
+                DateOfBirth = new DateTimeOffset(1990, 1, 20, 0, 0, 0, TimeSpan.Zero),
+                BirthPlace = "Dublin, Ireland"
+            };
+        }
+
+        // --- Default Values ---
+
+        [Test]
+        public void Applicant_DefaultValues_FirstName_IsEmpty()
+        {
+            var applicant = new Applicant();
+            Assert.That(applicant.FirstName, Is.EqualTo(string.Empty));
         }
 
         [Test]
-        public void Applicant_DefaultValues_AreNotNull()
+        public void Applicant_DefaultValues_LastName_IsEmpty()
         {
-            // Arrange
             var applicant = new Applicant();
-
-            // Assert
-            Assert.That(applicant.FirstName, Is.EqualTo(string.Empty));
             Assert.That(applicant.LastName, Is.EqualTo(string.Empty));
+        }
+
+        [Test]
+        public void Applicant_DefaultValues_UserId_IsEmpty()
+        {
+            var applicant = new Applicant();
             Assert.That(applicant.UserId, Is.EqualTo(string.Empty));
         }
 
         [Test]
-        public void Applicant_DateOfBirth_CanBeSet()
+        public void Applicant_DefaultValues_BirthLastName_IsEmpty()
         {
-            // Arrange
-            var applicant = new Applicant
-            {
-                DateOfBirth = new DateTimeOffset(1990, 1, 20, 0, 0, 0, TimeSpan.Zero)
-            };
-
-            // Assert
-            Assert.That(applicant.DateOfBirth, Is.Not.Null);
-            Assert.That(applicant.DateOfBirth?.Year, Is.EqualTo(1990));
-            Assert.That(applicant.DateOfBirth?.Month, Is.EqualTo(1));
-            Assert.That(applicant.DateOfBirth?.Day, Is.EqualTo(20));
-        }
-
-        [Test]
-        public void Applicant_DateOfBirth_IsNullByDefault()
-        {
-            // Arrange
             var applicant = new Applicant();
-
-            // Assert
-            Assert.That(applicant.DateOfBirth, Is.Null);
-        }
-
-        [Test]
-        public void Applicant_Gender_CanBeSet()
-        {
-            // Arrange
-            var applicant = new Applicant
-            {
-                Gender = "Female"
-            };
-
-            // Assert
-            Assert.That(applicant.Gender, Is.EqualTo("Female"));
-        }
-
-        [Test]
-        public void Applicant_BirthLastName_CanBeSet()
-        {
-            // Arrange
-            var applicant = new Applicant
-            {
-                BirthLastName = "Bloggs"
-            };
-
-            // Assert
-            Assert.That(applicant.BirthLastName, Is.EqualTo("Bloggs"));
-        }
-
-        [Test]
-        public void Applicant_BirthLastName_DefaultValue_IsEmpty()
-        {
-            // Arrange
-            var applicant = new Applicant();
-
-            // Assert
             Assert.That(applicant.BirthLastName, Is.EqualTo(string.Empty));
         }
 
         [Test]
-        public void Applicant_MothersLastName_CanBeSet()
+        public void Applicant_DefaultValues_MothersLastName_IsEmpty()
         {
-            // Arrange
-            var applicant = new Applicant
-            {
-                MothersLastName = "Smith"
-            };
-
-            // Assert
-            Assert.That(applicant.MothersLastName, Is.EqualTo("Smith"));
-        }
-
-        [Test]
-        public void Applicant_MothersLastName_DefaultValue_IsEmpty()
-        {
-            // Arrange
             var applicant = new Applicant();
-
-            // Assert
             Assert.That(applicant.MothersLastName, Is.EqualTo(string.Empty));
         }
 
         [Test]
-        public void Applicant_BirthPlace_CanBeSet()
+        public void Applicant_DefaultValues_BirthPlace_IsEmpty()
         {
-            // Arrange
-            var applicant = new Applicant
-            {
-                BirthPlace = "Dublin, Ireland"
-            };
-
-            // Assert
-            Assert.That(applicant.BirthPlace, Is.EqualTo("Dublin, Ireland"));
-        }
-
-        [Test]
-        public void Applicant_BirthPlace_DefaultValue_IsEmpty()
-        {
-            // Arrange
             var applicant = new Applicant();
-
-            // Assert
             Assert.That(applicant.BirthPlace, Is.EqualTo(string.Empty));
         }
 
         [Test]
+        public void Applicant_DefaultValues_DateOfBirth_IsNull()
+        {
+            var applicant = new Applicant();
+            Assert.That(applicant.DateOfBirth, Is.Null);
+        }
+
+        // --- Valid Model ---
+
+        [Test]
+        public void Applicant_ValidModel_PassesValidation()
+        {
+            var results = new List<ValidationResult>();
+            var isValid = Validator.TryValidateObject(_applicant, new ValidationContext(_applicant), results, true);
+            Assert.That(isValid, Is.True);
+        }
+
+        // --- FullName ---
+
+        [Test]
+        public void Applicant_FullName_ReturnsFirstAndLastName()
+        {
+            Assert.That(_applicant.FullName, Is.EqualTo("Joe Bloggs"));
+        }
+
+        // --- FirstName ---
+
+        [Test]
+        public void Applicant_FirstName_CanBeSet()
+        {
+            Assert.That(_applicant.FirstName, Is.EqualTo("Joe"));
+        }
+
+        [Test]
+        public void Applicant_FirstName_Required_FailsWhenEmpty()
+        {
+            _applicant.FirstName = string.Empty;
+            var results = new List<ValidationResult>();
+            Validator.TryValidateObject(_applicant, new ValidationContext(_applicant), results, true);
+            Assert.That(results, Has.Some.Matches<ValidationResult>(r =>
+                r.MemberNames.Contains("FirstName")));
+        }
+
+        [Test]
+        public void Applicant_FirstName_ExceedsMaxLength_FailsValidation()
+        {
+            _applicant.FirstName = new string('A', 51);
+            var results = new List<ValidationResult>();
+            Validator.TryValidateObject(_applicant, new ValidationContext(_applicant), results, true);
+            Assert.That(results, Has.Some.Matches<ValidationResult>(r =>
+                r.MemberNames.Contains("FirstName")));
+        }
+
+        [Test]
+        public void Applicant_FirstName_AtMaxLength_PassesValidation()
+        {
+            _applicant.FirstName = new string('A', 50);
+            var results = new List<ValidationResult>();
+            var isValid = Validator.TryValidateObject(_applicant, new ValidationContext(_applicant), results, true);
+            Assert.That(isValid, Is.True);
+        }
+
+        // --- LastName ---
+
+        [Test]
+        public void Applicant_LastName_CanBeSet()
+        {
+            Assert.That(_applicant.LastName, Is.EqualTo("Bloggs"));
+        }
+
+        [Test]
+        public void Applicant_LastName_Required_FailsWhenEmpty()
+        {
+            _applicant.LastName = string.Empty;
+            var results = new List<ValidationResult>();
+            Validator.TryValidateObject(_applicant, new ValidationContext(_applicant), results, true);
+            Assert.That(results, Has.Some.Matches<ValidationResult>(r =>
+                r.MemberNames.Contains("LastName")));
+        }
+
+        [Test]
+        public void Applicant_LastName_ExceedsMaxLength_FailsValidation()
+        {
+            _applicant.LastName = new string('A', 51);
+            var results = new List<ValidationResult>();
+            Validator.TryValidateObject(_applicant, new ValidationContext(_applicant), results, true);
+            Assert.That(results, Has.Some.Matches<ValidationResult>(r =>
+                r.MemberNames.Contains("LastName")));
+        }
+
+        // --- Gender ---
+
+        [Test]
+        public void Applicant_Gender_CanBeSet()
+        {
+            Assert.That(_applicant.Gender, Is.EqualTo("Male"));
+        }
+
+        [Test]
+        public void Applicant_Gender_Required_FailsWhenEmpty()
+        {
+            _applicant.Gender = string.Empty;
+            var results = new List<ValidationResult>();
+            Validator.TryValidateObject(_applicant, new ValidationContext(_applicant), results, true);
+            Assert.That(results, Has.Some.Matches<ValidationResult>(r =>
+                r.MemberNames.Contains("Gender")));
+        }
+
+        // --- DateOfBirth ---
+
+        [Test]
+        public void Applicant_DateOfBirth_CanBeSet()
+        {
+            Assert.That(_applicant.DateOfBirth, Is.Not.Null);
+            Assert.That(_applicant.DateOfBirth?.Year, Is.EqualTo(1990));
+            Assert.That(_applicant.DateOfBirth?.Month, Is.EqualTo(1));
+            Assert.That(_applicant.DateOfBirth?.Day, Is.EqualTo(20));
+        }
+
+        // --- BirthLastName ---
+
+        [Test]
+        public void Applicant_BirthLastName_CanBeSet()
+        {
+            Assert.That(_applicant.BirthLastName, Is.EqualTo("Smith"));
+        }
+
+        [Test]
+        public void Applicant_BirthLastName_IsOptional_PassesValidationWhenEmpty()
+        {
+            _applicant.BirthLastName = string.Empty;
+            var results = new List<ValidationResult>();
+            var isValid = Validator.TryValidateObject(_applicant, new ValidationContext(_applicant), results, true);
+            Assert.That(isValid, Is.True);
+        }
+
+        [Test]
+        public void Applicant_BirthLastName_ExceedsMaxLength_FailsValidation()
+        {
+            _applicant.BirthLastName = new string('A', 51);
+            var results = new List<ValidationResult>();
+            Validator.TryValidateObject(_applicant, new ValidationContext(_applicant), results, true);
+            Assert.That(results, Has.Some.Matches<ValidationResult>(r =>
+                r.MemberNames.Contains("BirthLastName")));
+        }
+
+        // --- MothersLastName ---
+
+        [Test]
+        public void Applicant_MothersLastName_CanBeSet()
+        {
+            Assert.That(_applicant.MothersLastName, Is.EqualTo("Smith"));
+        }
+
+        [Test]
+        public void Applicant_MothersLastName_IsOptional_PassesValidationWhenEmpty()
+        {
+            _applicant.MothersLastName = string.Empty;
+            var results = new List<ValidationResult>();
+            var isValid = Validator.TryValidateObject(_applicant, new ValidationContext(_applicant), results, true);
+            Assert.That(isValid, Is.True);
+        }
+
+        [Test]
+        public void Applicant_MothersLastName_ExceedsMaxLength_FailsValidation()
+        {
+            _applicant.MothersLastName = new string('A', 51);
+            var results = new List<ValidationResult>();
+            Validator.TryValidateObject(_applicant, new ValidationContext(_applicant), results, true);
+            Assert.That(results, Has.Some.Matches<ValidationResult>(r =>
+                r.MemberNames.Contains("MothersLastName")));
+        }
+
+        // --- BirthPlace ---
+
+        [Test]
+        public void Applicant_BirthPlace_CanBeSet()
+        {
+            Assert.That(_applicant.BirthPlace, Is.EqualTo("Dublin, Ireland"));
+        }
+
+        [Test]
+        public void Applicant_BirthPlace_IsOptional_PassesValidationWhenEmpty()
+        {
+            _applicant.BirthPlace = string.Empty;
+            var results = new List<ValidationResult>();
+            var isValid = Validator.TryValidateObject(_applicant, new ValidationContext(_applicant), results, true);
+            Assert.That(isValid, Is.True);
+        }
+
+        [Test]
+        public void Applicant_BirthPlace_ExceedsMaxLength_FailsValidation()
+        {
+            _applicant.BirthPlace = new string('A', 51);
+            var results = new List<ValidationResult>();
+            Validator.TryValidateObject(_applicant, new ValidationContext(_applicant), results, true);
+            Assert.That(results, Has.Some.Matches<ValidationResult>(r =>
+                r.MemberNames.Contains("BirthPlace")));
+        }
+
+        // --- ApplicantNumber ---
+
+        [Test]
         public void Applicant_ApplicantNumber_CanBeSet()
         {
-            // Arrange
-            var applicant = new Applicant
-            {
-                ApplicantNumber = 1
-            };
-
-            // Assert
-            Assert.That(applicant.ApplicantNumber, Is.EqualTo(1));
+            Assert.That(_applicant.ApplicantNumber, Is.EqualTo(1));
         }
+
+        // --- UserId ---
 
         [Test]
         public void Applicant_UserId_CanBeSet()
         {
-            // Arrange
-            var applicant = new Applicant
-            {
-                UserId = "abc-123-def-456"
-            };
-
-            // Assert
-            Assert.That(applicant.UserId, Is.EqualTo("abc-123-def-456"));
+            Assert.That(_applicant.UserId, Is.EqualTo("abc-123-def-456"));
         }
     }
 }

--- a/GardaVettingSystem/Models/Applicant.cs
+++ b/GardaVettingSystem/Models/Applicant.cs
@@ -24,7 +24,7 @@ namespace GardaVettingSystem.Models
         public string FullName => $"{FirstName} {LastName}";
 
         [StringLength(50, ErrorMessage = "Birth surname name cannot exceed 50 characters")]
-        [Display(Name = "Surname name at birth")]
+        [Display(Name = "Surname at birth")]
         public string BirthLastName { get; set; } = string.Empty;
 
         [StringLength(50, ErrorMessage = "Mother's last name cannot exceed 50 characters")]
@@ -43,7 +43,8 @@ namespace GardaVettingSystem.Models
         [Display(Name = "Place of birth")]
         public string BirthPlace { get; set; } = string.Empty;
 
-
+        // Navigation property - an applicant can have multiple addresses
+        public ICollection<ApplicantAddress> ApplicantAddresses { get; set; } = new List<ApplicantAddress>();
     }
 
 }

--- a/GardaVettingSystem/Pages/ApplicantAddresses/Create.cshtml
+++ b/GardaVettingSystem/Pages/ApplicantAddresses/Create.cshtml
@@ -5,18 +5,13 @@
         ViewData["Title"] = "Create";
         }
         
-        <h1>Create</h1>
-        
-    <h4>ApplicantAddress</h4>
+    <h1>Add Address</h1>
+    <h4>Enter your address details below.</h4>
     <hr />
     <div class="row">
     <div class="col-md-4">
     <form method="post">
     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-            <div class="form-group">
-                <label asp-for="ApplicantAddress.ApplicantNumber" class="control-label"></label>
-                <select asp-for="ApplicantAddress.ApplicantNumber" class ="form-control" asp-items="ViewBag.ApplicantNumber" ></select>
-            </div>
             <div class="form-group">
                 <span class="text-danger">*</span>
                 <label asp-for="ApplicantAddress.AddressLine" class="control-label"></label>
@@ -45,14 +40,15 @@
                 <span asp-validation-for="ApplicantAddress.ResidentTo" class="text-danger"></span>
             </div>
             <div class="form-group mt-3">
-                <input type="submit" value="Create" class="btn btn-primary" />
+                <button type="submit" class="btn btn-primary btn-sm">
+                    <i class="bi bi-plus-circle-fill"></i> Add Address
+                </button>
+                <a asp-page="/Applicants/Details" asp-route-id="@Model.ApplicantNumber" class="btn btn-secondary btn-sm">
+                    <i class="bi bi-arrow-left"></i> Cancel
+                </a>
             </div>
         </form>
     </div>
-</div>
-
-<div>
-    <a asp-page="Index">Back to List</a>
 </div>
 
 @section Scripts {

--- a/GardaVettingSystem/Pages/ApplicantAddresses/Create.cshtml.cs
+++ b/GardaVettingSystem/Pages/ApplicantAddresses/Create.cshtml.cs
@@ -1,32 +1,61 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.AspNetCore.Mvc.Rendering;
-using GardaVettingSystem.Data;
+﻿using GardaVettingSystem.Data;
 using GardaVettingSystem.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
 
 namespace GardaVettingSystem.Pages.ApplicantAddresses
 {
+    [Authorize]
     public class CreateModel : PageModel
     {
         private readonly GardaVettingSystemDbContext _context;
+        private readonly UserManager<IdentityUser> _userManager;
 
-        public CreateModel(GardaVettingSystemDbContext context)
+        public CreateModel(GardaVettingSystemDbContext context, UserManager<IdentityUser> userManager)
         {
             _context = context;
-        }
-
-        public IActionResult OnGet()
-        {
-        ViewData["ApplicantNumber"] = new SelectList(_context.Applicants, "ApplicantNumber", "FirstName");
-            return Page();
+            _userManager = userManager;
         }
 
         [BindProperty]
-        public ApplicantAddress ApplicantAddress { get; set; } = default!;
+        public int ApplicantNumber { get; set; }
+
+        [BindProperty]
+        public ApplicantAddress ApplicantAddress { get; set; } = new();
 
         // For more information, see https://aka.ms/RazorPagesCRUD.
+        public async Task<IActionResult> OnGetAsync()
+        {
+            var userId = _userManager.GetUserId(User);
+            var applicant = await _context.Applicants
+                .FirstOrDefaultAsync(a => a.UserId == userId);
+
+            if (applicant == null)
+            {
+                return RedirectToPage("/Applicants/Create");
+            }
+
+            ApplicantNumber = applicant.ApplicantNumber;
+            return Page();
+        }
+
         public async Task<IActionResult> OnPostAsync()
         {
+            var userId = _userManager.GetUserId(User);
+            var applicant = await _context.Applicants
+                .FirstOrDefaultAsync(a => a.UserId == userId);
+
+            if (applicant == null)
+            {
+                return RedirectToPage("/Applicants/Create");
+            }
+
+            ApplicantAddress.ApplicantNumber = applicant.ApplicantNumber;
+            ModelState.Remove("ApplicantAddress.ApplicantNumber");
+
             if (!ModelState.IsValid)
             {
                 return Page();
@@ -35,7 +64,7 @@ namespace GardaVettingSystem.Pages.ApplicantAddresses
             _context.ApplicantAddresses.Add(ApplicantAddress);
             await _context.SaveChangesAsync();
 
-            return RedirectToPage("./Index");
+            return RedirectToPage("/Applicants/Details", new { id = applicant.ApplicantNumber });
         }
     }
 }

--- a/GardaVettingSystem/Pages/ApplicantAddresses/Delete.cshtml
+++ b/GardaVettingSystem/Pages/ApplicantAddresses/Delete.cshtml
@@ -42,17 +42,17 @@
         <dd class="col-sm-10">
             @Html.DisplayFor(model => model.ApplicantAddress.ResidentTo)
         </dd>
-        <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.ApplicantAddress.Applicant)
-        </dt>
-        <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.ApplicantAddress.Applicant!.FirstName)
-        </dd>
     </dl>
     
     <form method="post">
         <input type="hidden" asp-for="ApplicantAddress.AddressId" />
-        <input type="submit" value="Delete" class="btn btn-danger" /> |
-        <a asp-page="./Index">Back to List</a>
+        <div class="form-group mt-3">
+            <button type="submit" class="btn btn-danger btn-sm">
+                <i class="bi bi-trash-fill"></i> Delete
+            </button>
+            <a asp-page="/Applicants/Details" asp-route-id="@Model.ApplicantAddress.ApplicantNumber" class="btn btn-secondary btn-sm">
+                <i class="bi bi-arrow-left"></i> Cancel
+            </a>
+        </div>
     </form>
 </div>

--- a/GardaVettingSystem/Pages/ApplicantAddresses/Delete.cshtml.cs
+++ b/GardaVettingSystem/Pages/ApplicantAddresses/Delete.cshtml.cs
@@ -1,18 +1,25 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using GardaVettingSystem.Data;
 using GardaVettingSystem.Models;
 
 namespace GardaVettingSystem.Pages.ApplicantAddresses
 {
+    [Authorize]
     public class DeleteModel : PageModel
     {
         private readonly GardaVettingSystemDbContext _context;
+        private readonly UserManager<IdentityUser> _userManager;
+        private const string ApplicantsDetailsPage = "/Applicants/Details";
+        private const string ApplicantsCreatePage = "/Applicants/Create";
 
-        public DeleteModel(GardaVettingSystemDbContext context)
+        public DeleteModel(GardaVettingSystemDbContext context, UserManager<IdentityUser> userManager)
         {
             _context = context;
+            _userManager = userManager;
         }
 
         [BindProperty]
@@ -21,38 +28,47 @@ namespace GardaVettingSystem.Pages.ApplicantAddresses
         public async Task<IActionResult> OnGetAsync(int? id)
         {
             if (id == null)
-            {
-                return NotFound();
-            }
+                return RedirectToPage(ApplicantsDetailsPage);
 
-            var applicantaddress = await _context.ApplicantAddresses.FirstOrDefaultAsync(m => m.AddressId == id);
+            var userId = _userManager.GetUserId(User);
+            var applicant = await _context.Applicants
+                .FirstOrDefaultAsync(a => a.UserId == userId);
 
-            if (applicantaddress is not null)
-            {
-                ApplicantAddress = applicantaddress;
+            if (applicant == null)
+                return RedirectToPage(ApplicantsCreatePage);
 
-                return Page();
-            }
+            var address = await _context.ApplicantAddresses
+                .FirstOrDefaultAsync(a => a.AddressId == id && a.ApplicantNumber == applicant.ApplicantNumber);
 
-            return NotFound();
+            if (address == null)
+                return RedirectToPage(ApplicantsDetailsPage, new { id = applicant.ApplicantNumber });
+
+            ApplicantAddress = address;
+            return Page();
         }
 
         public async Task<IActionResult> OnPostAsync(int? id)
         {
             if (id == null)
-            {
-                return NotFound();
-            }
+                return RedirectToPage(ApplicantsDetailsPage);
 
-            var applicantaddress = await _context.ApplicantAddresses.FindAsync(id);
-            if (applicantaddress != null)
+            var userId = _userManager.GetUserId(User);
+            var applicant = await _context.Applicants
+                .FirstOrDefaultAsync(a => a.UserId == userId);
+
+            if (applicant == null)
+                return RedirectToPage(ApplicantsCreatePage);
+
+            var address = await _context.ApplicantAddresses
+                .FirstOrDefaultAsync(a => a.AddressId == id && a.ApplicantNumber == applicant.ApplicantNumber);
+
+            if (address != null)
             {
-                ApplicantAddress = applicantaddress;
-                _context.ApplicantAddresses.Remove(ApplicantAddress);
+                _context.ApplicantAddresses.Remove(address);
                 await _context.SaveChangesAsync();
             }
 
-            return RedirectToPage("./Index");
+            return RedirectToPage(ApplicantsDetailsPage, new { id = applicant.ApplicantNumber });
         }
     }
 }

--- a/GardaVettingSystem/Pages/ApplicantAddresses/Edit.cshtml
+++ b/GardaVettingSystem/Pages/ApplicantAddresses/Edit.cshtml
@@ -15,11 +15,6 @@
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <input type="hidden" asp-for="ApplicantAddress.AddressId" />
             <div class="form-group">
-                <label asp-for="ApplicantAddress.ApplicantNumber" class="control-label"></label>
-                <select asp-for="ApplicantAddress.ApplicantNumber" class="form-control" asp-items="ViewBag.ApplicantNumber" ></select>
-                <span asp-validation-for="ApplicantAddress.ApplicantNumber" class="text-danger"></span>
-            </div>
-            <div class="form-group">
 <span class="text-danger">*</span>
                 <label asp-for="ApplicantAddress.AddressLine" class="control-label"></label>
                 <input asp-for="ApplicantAddress.AddressLine" class="form-control" aria-required="true"/>
@@ -47,14 +42,15 @@
                 <span asp-validation-for="ApplicantAddress.ResidentTo" class="text-danger"></span>
             </div>
             <div class="form-group mt-3">
-                <input type="submit" value="Save" class="btn btn-primary" />
+                <button type="submit" class="btn btn-primary btn-sm">
+                    <i class="bi bi-floppy"></i> Save
+                </button>
+                <a asp-page="/Applicants/Details" asp-route-id="@Model.ApplicantAddress.ApplicantNumber" class="btn btn-secondary btn-sm">
+                    <i class="bi bi-arrow-left"></i> Cancel
+                </a>
             </div>
         </form>
     </div>
-</div>
-
-<div>
-    <a asp-page="./Index">Back to List</a>
 </div>
 
 @section Scripts {

--- a/GardaVettingSystem/Pages/ApplicantAddresses/Edit.cshtml.cs
+++ b/GardaVettingSystem/Pages/ApplicantAddresses/Edit.cshtml.cs
@@ -1,19 +1,25 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using GardaVettingSystem.Data;
 using GardaVettingSystem.Models;
 
 namespace GardaVettingSystem.Pages.ApplicantAddresses
 {
+    [Authorize]
     public class EditModel : PageModel
     {
         private readonly GardaVettingSystemDbContext _context;
+        private readonly UserManager<IdentityUser> _userManager;
+        private const string ApplicantsDetailsPage = "/Applicants/Details";
+        private const string ApplicantsCreatePage = "/Applicants/Create";
 
-        public EditModel(GardaVettingSystemDbContext context)
+        public EditModel(GardaVettingSystemDbContext context, UserManager<IdentityUser> userManager)
         {
             _context = context;
+            _userManager = userManager;
         }
 
         [BindProperty]
@@ -22,28 +28,46 @@ namespace GardaVettingSystem.Pages.ApplicantAddresses
         public async Task<IActionResult> OnGetAsync(int? id)
         {
             if (id == null)
-            {
-                return NotFound();
-            }
+                return RedirectToPage(ApplicantsDetailsPage);
 
-            var applicantaddress =  await _context.ApplicantAddresses.FirstOrDefaultAsync(m => m.AddressId == id);
-            if (applicantaddress == null)
-            {
-                return NotFound();
-            }
-            ApplicantAddress = applicantaddress;
-           ViewData["ApplicantNumber"] = new SelectList(_context.Applicants, "ApplicantNumber", "FirstName");
+            var userId = _userManager.GetUserId(User);
+            var applicant = await _context.Applicants
+                .FirstOrDefaultAsync(a => a.UserId == userId);
+
+            if (applicant == null)
+                return RedirectToPage(ApplicantsCreatePage);
+
+            var address = await _context.ApplicantAddresses
+                .FirstOrDefaultAsync(a => a.AddressId == id && a.ApplicantNumber == applicant.ApplicantNumber);
+
+            if (address == null)
+                return RedirectToPage(ApplicantsDetailsPage, new { id = applicant.ApplicantNumber });
+
+            ApplicantAddress = address;
             return Page();
         }
 
-        // To protect from overposting attacks, enable the specific properties you want to bind to.
-        // For more information, see https://aka.ms/RazorPagesCRUD.
         public async Task<IActionResult> OnPostAsync()
         {
+            var userId = _userManager.GetUserId(User);
+            var applicant = await _context.Applicants
+                .FirstOrDefaultAsync(a => a.UserId == userId);
+
+            if (applicant == null)
+                return RedirectToPage(ApplicantsCreatePage);
+
+            // Verify ownership
+            var existing = await _context.ApplicantAddresses
+                .FirstOrDefaultAsync(a => a.AddressId == ApplicantAddress.AddressId && a.ApplicantNumber == applicant.ApplicantNumber);
+
+            if (existing == null)
+                return RedirectToPage(ApplicantsDetailsPage, new { id = applicant.ApplicantNumber });
+
+            ModelState.Remove("ApplicantAddress.ApplicantNumber");
+            ApplicantAddress.ApplicantNumber = applicant.ApplicantNumber;
+
             if (!ModelState.IsValid)
-            {
                 return Page();
-            }
 
             _context.Attach(ApplicantAddress).State = EntityState.Modified;
 
@@ -53,22 +77,13 @@ namespace GardaVettingSystem.Pages.ApplicantAddresses
             }
             catch (DbUpdateConcurrencyException)
             {
-                if (!ApplicantAddressExists(ApplicantAddress.AddressId))
-                {
+                if (!await _context.ApplicantAddresses.AnyAsync(e => e.AddressId == ApplicantAddress.AddressId))
                     return NotFound();
-                }
                 else
-                {
                     throw;
-                }
             }
 
-            return RedirectToPage("./Index");
-        }
-
-        private bool ApplicantAddressExists(int id)
-        {
-            return _context.ApplicantAddresses.Any(e => e.AddressId == id);
+            return RedirectToPage(ApplicantsDetailsPage, new { id = applicant.ApplicantNumber });
         }
     }
 }

--- a/GardaVettingSystem/Pages/Applicants/Create.cshtml
+++ b/GardaVettingSystem/Pages/Applicants/Create.cshtml
@@ -63,7 +63,7 @@
                 <button type="submit" class="btn btn-primary btn-sm">
                     <i class="bi bi-plus-circle"></i> Create
                 </button>
-                <a asp-page="Index" class="btn btn-secondary btn-sm">
+                <a asp-page="/Index" class="btn btn-secondary btn-sm">
                     <i class="bi bi-arrow-left"></i> Cancel
                 </a>
             </div>

--- a/GardaVettingSystem/Pages/Applicants/Create.cshtml.cs
+++ b/GardaVettingSystem/Pages/Applicants/Create.cshtml.cs
@@ -20,7 +20,7 @@ namespace GardaVettingSystem.Pages.Applicants
             _userManager = userManager;
         }
 
-        public async Task<IActionResult> OnGet()
+        public async Task<IActionResult> OnGetAsync()
         {
             string? userId = _userManager.GetUserId(User);
 
@@ -62,7 +62,7 @@ namespace GardaVettingSystem.Pages.Applicants
             _context.Applicants.Add(Applicant);
             await _context.SaveChangesAsync();
 
-            return RedirectToPage("./Index");
+            return RedirectToPage("./Details", new { id = Applicant.ApplicantNumber });
         }
     }
 }

--- a/GardaVettingSystem/Pages/Applicants/Delete.cshtml.cs
+++ b/GardaVettingSystem/Pages/Applicants/Delete.cshtml.cs
@@ -13,6 +13,7 @@ namespace GardaVettingSystem.Pages.Applicants
     {
         private readonly GardaVettingSystemDbContext _context;
         private readonly UserManager<IdentityUser> _userManager;
+        private const string ApplicantsCreatePage = "/Applicants/Create";
 
         public DeleteModel(GardaVettingSystemDbContext context, UserManager<IdentityUser> userManager)
         {
@@ -27,7 +28,7 @@ namespace GardaVettingSystem.Pages.Applicants
         {
             if (id == null)
             {
-                return RedirectToPage("/Applicants/Index");
+                return RedirectToPage(ApplicantsCreatePage);
             }
 
             string? userId = _userManager.GetUserId(User);
@@ -41,14 +42,14 @@ namespace GardaVettingSystem.Pages.Applicants
                 return Page();
             }
 
-            return RedirectToPage("/Applicants/Index");
+            return RedirectToPage(ApplicantsCreatePage);
         }
 
         public async Task<IActionResult> OnPostAsync(int? id)
         {
             if (id == null)
             {
-                return RedirectToPage("/Applicants/Index");
+                return RedirectToPage(ApplicantsCreatePage);
             }
 
             string? userId = _userManager.GetUserId(User);

--- a/GardaVettingSystem/Pages/Applicants/Details.cshtml
+++ b/GardaVettingSystem/Pages/Applicants/Details.cshtml
@@ -55,12 +55,58 @@
         </dd>
     </dl>
 </div>
+<div class="mt-4">
+    <h4>Address History</h4>
+    <hr />
+    @if (Model.Applicant.ApplicantAddresses != null && Model.Applicant.ApplicantAddresses.Any())
+    {
+        <table class="table table-sm">
+            <thead>
+                <tr>
+                    <th>Address</th>
+                    <th>Postcode</th>
+                    <th>Country</th>
+                    <th>From</th>
+                    <th>To</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var address in Model.Applicant.ApplicantAddresses)
+                {
+                    <tr>
+                        <td>@address.AddressLine</td>
+                        <td>@address.Postcode</td>
+                        <td>@address.Country</td>
+                        <td>@address.ResidentFrom</td>
+                        <td>@(address.ResidentTo.HasValue? address.ResidentTo.ToString() : "Current")</td>
+                        <td>
+                            <a asp-page="/ApplicantAddresses/Edit" asp-route-id="@address.AddressId" class="btn btn-primary btn-sm">
+                                <i class="bi bi-pencil-fill"></i>
+                            </a>
+                            <a asp-page="/ApplicantAddresses/Delete" asp-route-id="@address.AddressId" class="btn btn-danger btn-sm">
+                                <i class="bi bi-trash-fill"></i>
+                            </a>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
+    else
+    {
+        <p class="text-muted">No addresses added yet.</p>
+    }
+</div>
 <div>
     <a asp-page="/Applicants/Index" class="btn btn-secondary btn-sm">
         <i class="bi bi-house-fill"></i> Home
     </a>
     <a asp-page="./Edit" asp-route-id="@Model.Applicant.ApplicantNumber" class="btn btn-primary btn-sm">
         <i class="bi bi-pencil-fill"></i> Edit
+    </a>
+    <a asp-page="/ApplicantAddresses/Create" class="btn btn-success btn-sm">
+        <i class="bi bi-plus-circle-fill"></i> Add Address
     </a>
     <a asp-page="./Delete" asp-route-id="@Model.Applicant.ApplicantNumber" class="btn btn-danger btn-sm">
         <i class="bi bi-trash-fill"></i> Delete

--- a/GardaVettingSystem/Pages/Applicants/Details.cshtml.cs
+++ b/GardaVettingSystem/Pages/Applicants/Details.cshtml.cs
@@ -32,6 +32,7 @@ namespace GardaVettingSystem.Pages.Applicants
 
             string? userId = _userManager.GetUserId(User);
             Applicant? applicant = await _context.Applicants
+                .Include(a => a.ApplicantAddresses)
                 .FirstOrDefaultAsync(m => m.ApplicantNumber == id && m.UserId == userId);
 
             if (applicant is not null)
@@ -42,7 +43,7 @@ namespace GardaVettingSystem.Pages.Applicants
             }
 
             // Record not found or doesn't belong to this user - redirect to their own profile
-            return RedirectToPage("/Applicants/Index");
+            return RedirectToPage("/Applicants/Create");
         }
     }
 }

--- a/GardaVettingSystem/Pages/Applicants/Edit.cshtml
+++ b/GardaVettingSystem/Pages/Applicants/Edit.cshtml
@@ -64,7 +64,7 @@
                 <button type="submit" class="btn btn-primary btn-sm">
                     <i class="bi bi-floppy"></i> Save
                 </button>
-                <a asp-page="./Index" class="btn btn-secondary btn-sm">
+                <a asp-page="./Details" asp-route-id="@Model.Applicant.ApplicantNumber" class="btn btn-secondary btn-sm">
                     <i class="bi bi-arrow-left"></i> Cancel
                 </a>
             </div>

--- a/GardaVettingSystem/Pages/Applicants/Edit.cshtml.cs
+++ b/GardaVettingSystem/Pages/Applicants/Edit.cshtml.cs
@@ -14,6 +14,7 @@ namespace GardaVettingSystem.Pages.Applicants
     {
         private readonly GardaVettingSystemDbContext _context;
         private readonly UserManager<IdentityUser> _userManager;
+        private const string ApplicantsCreatePage = "/Applicants/Create";
 
         public EditModel(GardaVettingSystemDbContext context, UserManager<IdentityUser> userManager)
         {
@@ -28,7 +29,7 @@ namespace GardaVettingSystem.Pages.Applicants
         {
             if (id == null)
             {
-                return RedirectToPage("/Applicants/Index");
+                return RedirectToPage(ApplicantsCreatePage);
             }
 
             string? userId = _userManager.GetUserId(User);
@@ -37,7 +38,7 @@ namespace GardaVettingSystem.Pages.Applicants
 
             if (applicant == null)
             {
-                return RedirectToPage("/Applicants/Index");
+                return RedirectToPage(ApplicantsCreatePage);
             }
             Applicant = applicant;
             return Page();
@@ -56,7 +57,7 @@ namespace GardaVettingSystem.Pages.Applicants
 
             if (existing == null)
             {
-                return RedirectToPage("/Applicants/Index");
+                return RedirectToPage(ApplicantsCreatePage);
             }
 
             if (!ModelState.IsValid)
@@ -72,7 +73,7 @@ namespace GardaVettingSystem.Pages.Applicants
             }
             catch (DbUpdateConcurrencyException)
             {
-                if (!ApplicantExists(Applicant.ApplicantNumber))
+                if (!await ApplicantExistsAsync(Applicant.ApplicantNumber))
                 {
                     return NotFound();
                 }
@@ -85,9 +86,9 @@ namespace GardaVettingSystem.Pages.Applicants
             return RedirectToPage("./Details", new { id = Applicant.ApplicantNumber });
         }
 
-        private bool ApplicantExists(int id)
+        private async Task<bool> ApplicantExistsAsync(int id)
         {
-            return _context.Applicants.Any(e => e.ApplicantNumber == id);
+            return await _context.Applicants.AnyAsync(e => e.ApplicantNumber == id);
         }
     }
 }

--- a/GardaVettingSystem/Pages/Applicants/Index.cshtml.cs
+++ b/GardaVettingSystem/Pages/Applicants/Index.cshtml.cs
@@ -1,9 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.EntityFrameworkCore;
-using GardaVettingSystem.Data;
+﻿using GardaVettingSystem.Data;
 using GardaVettingSystem.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
 
 namespace GardaVettingSystem.Pages.Applicants
 {
@@ -21,13 +22,16 @@ namespace GardaVettingSystem.Pages.Applicants
 
         public IList<Applicant> Applicant { get;set; } = default!;
 
-        public async Task OnGetAsync()
+        public async Task<IActionResult> OnGetAsync()
         {
             string? userId = _userManager.GetUserId(User);
+            var applicant = await _context.Applicants
+                .FirstOrDefaultAsync(a => a.UserId == userId);
 
-            Applicant = await _context.Applicants
-                .Where(a => a.UserId == userId)
-                .ToListAsync();
+            if (applicant == null)
+                return RedirectToPage("/Applicants/Create");
+
+            return RedirectToPage("/Applicants/Details", new { id = applicant.ApplicantNumber });
         }
     }
 }


### PR DESCRIPTION
## Summary
Secured the scaffolded ApplicantAddresses pages with ownership checks and wires address history into the Applicants/Details profile page.

## Changes
- ApplicantAddresses Create, Edit, Delete pages reworked — ApplicantNumber set server-side from logged-in user's identity, never from the form
- Ownership verification added to Edit and Delete — users can only modify their own addresses
- Address history table added to Applicants/Details page via eager loading with .Include()
- Navigation property added to Applicant model (ICollection<ApplicantAddress>)
- Applicants/Index refactored to smart redirect — routes logged-in users directly to their Details page
- All redirects across Applicants and ApplicantAddresses folders reviewed and corrected for consistency with the documented workflow
- Repeated page route strings extracted to private constants (SonarQube warning S1192)
- Synchronous .Any() replaced with AnyAsync() in async methods (SonarQube warning S6966)
- NUnit tests added for ApplicantAddress model
- ApplicantTests refactored for consistency — SetUp, validation tests and organised sections

## Testing
All NUnit tests passing