### PR TITLE
feat: PDF export and access code generation guard

### DIFF
--- a/GardaVettingSystem/GardaVettingSystem.csproj
+++ b/GardaVettingSystem/GardaVettingSystem.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
     <PackageReference Include="NuGet.Packaging" Version="7.3.1" />
     <PackageReference Include="NuGet.Protocol" Version="7.3.1" />
+    <PackageReference Include="QuestPDF" Version="2026.2.4" />
   </ItemGroup>
 
 </Project>

--- a/GardaVettingSystem/Pages/AccessCodes/Create.cshtml.cs
+++ b/GardaVettingSystem/Pages/AccessCodes/Create.cshtml.cs
@@ -62,10 +62,16 @@ namespace GardaVettingSystem.Pages.AccessCodes
         {
             var userId = _userManager.GetUserId(User);
             var applicant = await _context.Applicants
+                .Include(a => a.ApplicantAddresses)
                 .FirstOrDefaultAsync(a => a.UserId == userId);
 
             if (applicant == null)
                 return RedirectToPage(ApplicantsCreatePage);
+
+            if (applicant.ApplicantAddresses.Count == 0)
+            {
+                return RedirectToPage(ApplicantsDetailsPage, new { id = applicant.ApplicantNumber });
+            }
 
             ApplicantNumber = applicant.ApplicantNumber;
             return Page();
@@ -83,10 +89,16 @@ namespace GardaVettingSystem.Pages.AccessCodes
         {
             var userId = _userManager.GetUserId(User);
             var applicant = await _context.Applicants
+                .Include(a => a.ApplicantAddresses)
                 .FirstOrDefaultAsync(a => a.UserId == userId);
 
             if (applicant == null)
                 return RedirectToPage(ApplicantsCreatePage);
+
+            if (applicant.ApplicantAddresses.Count == 0)
+            {
+                return RedirectToPage(ApplicantsDetailsPage, new { id = applicant.ApplicantNumber });
+            }
 
             AccessCode.ApplicantNumber = applicant.ApplicantNumber;
             AccessCode.Code = GenerateAccessCode();

--- a/GardaVettingSystem/Pages/Applicants/Details.cshtml
+++ b/GardaVettingSystem/Pages/Applicants/Details.cshtml
@@ -111,9 +111,16 @@
 <div class="mt-4">
     <h4>Access Codes</h4>
     <div>
-        <a asp-page="/AccessCodes/Create" class="btn btn-info btn-sm">
-            <i class="bi bi-key-fill"></i> Generate Access Code
-        </a>
+        @if (Model.Applicant.ApplicantAddresses != null && Model.Applicant.ApplicantAddresses.Any())
+        {
+            <a asp-page="/AccessCodes/Create" class="btn btn-info btn-sm">
+                <i class="bi bi-key-fill"></i> Generate Access Code
+            </a>
+        }
+        else
+        {
+            <p class="text-muted">Add at least one address before generating an access code.</p>
+        }
     </div>
     <hr />
     @if (Model.Applicant.AccessCodes != null && Model.Applicant.AccessCodes.Any())
@@ -121,7 +128,8 @@
         <table class="table table-sm align-middle">
             <thead>
                 <tr>
-                    <th>Code</th>
+                    <th style="width: 1%">Code</th>
+                    <th></th>
                     <th>Organisation</th>
                     <th>Created</th>
                     <th>Expires</th>
@@ -133,9 +141,9 @@
                 @foreach (var code in Model.Applicant.AccessCodes)
                 {
                     <tr>
-                        <td class="text-nowrap">
-                            <strong>@code.Code</strong>
-                            <button type="button" class="btn btn-outline-primary btn-sm ms-4"
+                        <td style="width: 1%"><strong>@code.Code</strong></td>
+                        <td>
+                            <button type="button" class="btn btn-outline-primary btn-sm"
                                     onclick="copyToClipboard('@code.Code', this)"
                                     title="Copy code">
                                 <i class="bi bi-clipboard"></i>
@@ -170,27 +178,33 @@
                 }
             </tbody>
         </table>
-
-        @section Scripts {
-            <script>
-                function copyToClipboard(text, button) {
-                    navigator.clipboard.writeText(text).then(function () {
-                        button.innerHTML = '<i class="bi bi-clipboard-check"></i>';
-                        setTimeout(function () {
-                            button.innerHTML = '<i class="bi bi-clipboard"></i>';
-                        }, 2000);
-                    });
-                }
-            </script>
-        }
+  
     }
     else
     {
         <p class="text-muted">No access codes generated yet.</p>
     }
 </div>
-<div>
+<div class="mt-3">
+    <form method="post" asp-page-handler="DownloadPdf" asp-route-id="@Model.Applicant.ApplicantNumber" class="d-inline">
+        <button type="submit" class="btn btn-secondary btn-sm">
+            <i class="bi bi-file-earmark-pdf-fill"></i> Download PDF
+        </button>
+    </form>
     <a asp-page="./Delete" asp-route-id="@Model.Applicant.ApplicantNumber" class="btn btn-danger btn-sm">
         <i class="bi bi-trash-fill"></i> Delete My Profile
     </a>
 </div>
+
+@section Scripts {
+    <script>
+        function copyToClipboard(text, button) {
+            navigator.clipboard.writeText(text).then(function () {
+                button.innerHTML = '<i class="bi bi-clipboard-check"></i>';
+                setTimeout(function () {
+                    button.innerHTML = '<i class="bi bi-clipboard"></i>';
+                }, 2000);
+            });
+        }
+    </script>
+}

--- a/GardaVettingSystem/Pages/Applicants/Details.cshtml.cs
+++ b/GardaVettingSystem/Pages/Applicants/Details.cshtml.cs
@@ -1,11 +1,12 @@
 ﻿
+using GardaVettingSystem.Data;
+using GardaVettingSystem.Models;
+using GardaVettingSystem.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
-using GardaVettingSystem.Data;
-using GardaVettingSystem.Models;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Identity;
 
 namespace GardaVettingSystem.Pages.Applicants
 {
@@ -19,16 +20,19 @@ namespace GardaVettingSystem.Pages.Applicants
     {
         private readonly GardaVettingSystemDbContext _context;
         private readonly UserManager<IdentityUser> _userManager;
+        private readonly VettingPdfService _pdfService;
 
         /// <summary>
         /// Initialises a new instance of <see cref="DetailsModel"/> with the required services.
         /// </summary>
         /// <param name="context">The database context.</param>
         /// <param name="userManager">The ASP.NET Identity user manager.</param>
-        public DetailsModel(GardaVettingSystemDbContext context, UserManager<IdentityUser> userManager)
+        /// <param name="pdfService">The PDF generation service.</param>
+        public DetailsModel(GardaVettingSystemDbContext context, UserManager<IdentityUser> userManager, VettingPdfService pdfService)
         {
             _context = context;
             _userManager = userManager;
+            _pdfService = pdfService;
         }
 
         /// <summary>
@@ -67,6 +71,31 @@ namespace GardaVettingSystem.Pages.Applicants
 
             // Record not found or doesn't belong to this user - redirect to their own profile
             return RedirectToPage("/Applicants/Create");
+        }
+
+        /// <summary>
+        /// Handles POST requests for PDF export. Generates a PDF of the applicant's
+        /// vetting profile and returns it as a file download.
+        /// </summary>
+        /// <param name="id">The ApplicantNumber to export.</param>
+        /// <returns>A PDF file download, or a redirect if the profile is not found.</returns>
+        public async Task<IActionResult> OnPostDownloadPdfAsync(int? id)
+        {
+            if (id == null)
+                return RedirectToPage("/Applicants/Create");
+
+            string? userId = _userManager.GetUserId(User);
+            Applicant? applicant = await _context.Applicants
+                .Include(a => a.ApplicantAddresses)
+                .FirstOrDefaultAsync(m => m.ApplicantNumber == id && m.UserId == userId);
+
+            if (applicant == null)
+                return RedirectToPage("/Applicants/Create");
+
+            var pdf = _pdfService.GeneratePdf(applicant);
+            var fileName = $"{DateTimeOffset.UtcNow:yyyyMMdd}_VettingProfile_{applicant.FullName.Replace(" ", "_", StringComparison.OrdinalIgnoreCase)}.pdf";
+
+            return File(pdf, "application/pdf", fileName);
         }
     }
 }

--- a/GardaVettingSystem/Program.cs
+++ b/GardaVettingSystem/Program.cs
@@ -1,4 +1,5 @@
 using GardaVettingSystem.Data;
+using GardaVettingSystem.Services;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
@@ -14,6 +15,7 @@ builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 builder.Services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = false)
     .AddEntityFrameworkStores<GardaVettingSystemDbContext>();
 builder.Services.AddRazorPages();
+builder.Services.AddScoped<VettingPdfService>();
 
 var app = builder.Build();
 

--- a/GardaVettingSystem/Services/VettingPdfService.cs
+++ b/GardaVettingSystem/Services/VettingPdfService.cs
@@ -91,7 +91,7 @@ namespace GardaVettingSystem.Services
                                     table.Cell().Padding(5).Text(address.Postcode);
                                     table.Cell().Padding(5).Text(address.Country);
                                     table.Cell().Padding(5).Text(address.ResidentFrom?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
-                                    table.Cell().Padding(5).Text(address.ResidentTo.HasValue ? address.ResidentTo?.ToString(CultureInfo.InvariantCulture)! : "Current");
+                                    table.Cell().Padding(5).Text(address.ResidentTo.HasValue ? address.ResidentTo.Value.ToString(CultureInfo.InvariantCulture)! : "Current");
                                 }
                             });
                         }

--- a/GardaVettingSystem/Services/VettingPdfService.cs
+++ b/GardaVettingSystem/Services/VettingPdfService.cs
@@ -1,0 +1,123 @@
+﻿using System.Globalization;
+using GardaVettingSystem.Models;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
+namespace GardaVettingSystem.Services
+{
+    /// <summary>
+    /// Generates a PDF document containing an applicant's vetting information.
+    /// Used to provide a downloadable export of profile data for organisations
+    /// that cannot access the system directly.
+    /// </summary>
+    public class VettingPdfService
+    {
+        /// <summary>
+        /// Generates a PDF document for the given applicant profile.
+        /// </summary>
+        /// <param name="applicant">The applicant profile including address history.</param>
+        /// <returns>A byte array containing the generated PDF.</returns>
+        public byte[] GeneratePdf(Applicant applicant)
+        {
+            QuestPDF.Settings.License = LicenseType.Community;
+
+            return Document.Create(container =>
+            {
+                container.Page(page =>
+                {
+                    page.Size(PageSizes.A4);
+                    page.Margin(2, Unit.Centimetre);
+                    page.DefaultTextStyle(x => x.FontSize(11));
+
+                    page.Header().Column(col =>
+                    {
+                        col.Item().Text("Garda Vetting Data Reuse System")
+                            .FontSize(18).Bold();
+                        col.Item().Text("Applicant Vetting Profile")
+                            .FontSize(13).FontColor(Colors.Grey.Darken2);
+                        col.Item().PaddingTop(5).LineHorizontal(1);
+                    });
+
+                    page.Content().PaddingTop(20).Column(col =>
+                    {
+                        // Personal Details
+                        col.Item().Text("Personal Details").FontSize(13).Bold();
+                        col.Item().PaddingTop(5).Table(table =>
+                        {
+                            table.ColumnsDefinition(columns =>
+                            {
+                                columns.RelativeColumn(2);
+                                columns.RelativeColumn(3);
+                            });
+
+                            AddRow(table, "Full Name", applicant.FullName);
+                            AddRow(table, "Date of Birth", applicant.DateOfBirth?.ToString("d", CultureInfo.InvariantCulture) ?? string.Empty);
+                            AddRow(table, "Gender", applicant.Gender);
+                            AddRow(table, "Place of Birth", applicant.BirthPlace);
+                            AddRow(table, "Surname at Birth", applicant.BirthLastName);
+                            AddRow(table, "Mother's Last Name", applicant.MothersLastName);
+                        });
+
+                        // Address History
+                        col.Item().PaddingTop(20).Text("Address History").FontSize(13).Bold();
+
+                        if (applicant.ApplicantAddresses != null && applicant.ApplicantAddresses.Count > 0)
+                        {
+                            col.Item().PaddingTop(5).Table(table =>
+                            {
+                                table.ColumnsDefinition(columns =>
+                                {
+                                    columns.RelativeColumn(4);
+                                    columns.RelativeColumn(2);
+                                    columns.RelativeColumn(2);
+                                    columns.RelativeColumn(1);
+                                    columns.RelativeColumn(1);
+                                });
+
+                                // Header row
+                                table.Header(header =>
+                                {
+                                    header.Cell().Background(Colors.Grey.Lighten2).Padding(5).Text("Address").Bold();
+                                    header.Cell().Background(Colors.Grey.Lighten2).Padding(5).Text("Postcode").Bold();
+                                    header.Cell().Background(Colors.Grey.Lighten2).Padding(5).Text("Country").Bold();
+                                    header.Cell().Background(Colors.Grey.Lighten2).Padding(5).Text("From").Bold();
+                                    header.Cell().Background(Colors.Grey.Lighten2).Padding(5).Text("To").Bold();
+                                });
+
+                                foreach (var address in applicant.ApplicantAddresses)
+                                {
+                                    table.Cell().Padding(5).Text(address.AddressLine);
+                                    table.Cell().Padding(5).Text(address.Postcode);
+                                    table.Cell().Padding(5).Text(address.Country);
+                                    table.Cell().Padding(5).Text(address.ResidentFrom?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+                                    table.Cell().Padding(5).Text(address.ResidentTo.HasValue ? address.ResidentTo?.ToString(CultureInfo.InvariantCulture)! : "Current");
+                                }
+                            });
+                        }
+                        else
+                        {
+                            col.Item().PaddingTop(5).Text("No address history available.")
+                                .FontColor(Colors.Grey.Darken1);
+                        }
+                    });
+
+                    page.Footer().AlignCenter().Text(text =>
+                    {
+                        text.Span("Generated by Garda Vetting Data Reuse System — ");
+                        text.Span(DateTimeOffset.UtcNow.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture));
+                    });
+                });
+            }).GeneratePdf();
+        }
+
+        /// <summary>
+        /// Adds a label/value row to a two-column table.
+        /// </summary>
+        private static void AddRow(TableDescriptor table, string label, string value)
+        {
+            table.Cell().Padding(4).Text(label).Bold();
+            table.Cell().Padding(4).Text(value);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds PDF export of applicant vetting profile and restricts access code generation to applicants who have at least one address on file.

## Changes
- Added:
  - VettingPdfService — generates a formatted A4 PDF containing personal details and address history
  - Download PDF button on Applicants/Details page
  - QuestPDF NuGet package
- Updated:
  - AccessCodes/Create — blocks code generation if no addresses exist
  - Applicants/Details — Generate Access Code button hidden if no addresses, replaced with explanatory message
  - Clipboard copy button moved to its own column for consistent alignment

## Type of Change
- [x] New feature

## Testing
- [x] All existing NUnit tests passing
- [x] Manually tested — PDF download, long address wrapping, no-address guard on access code generation

## Impact
- Modules: AccessCodes, Applicants
- Database: No changes

## Breaking Changes
- [x] No

## Related
- Milestone: Implementation Chapter — 3 May 2026
- Branch: feature/pdf-export