### PR TITLE
fix: SonarQube warnings and field order consistency

### DIFF
--- a/GardaVettingSystem/Pages/Applicants/Create.cshtml
+++ b/GardaVettingSystem/Pages/Applicants/Create.cshtml
@@ -26,14 +26,10 @@
                 <span asp-validation-for="Applicant.LastName" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Applicant.BirthLastName" class="control-label"></label>
-                <input asp-for="Applicant.BirthLastName" class="form-control" />
-                <span asp-validation-for="Applicant.BirthLastName" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="Applicant.MothersLastName" class="control-label"></label>
-                <input asp-for="Applicant.MothersLastName" class="form-control" />
-                <span asp-validation-for="Applicant.MothersLastName" class="text-danger"></span>
+                <span class="text-danger">*</span>
+                <label asp-for="Applicant.DateOfBirth" class="control-label"></label>
+                <input asp-for="Applicant.DateOfBirth" class="form-control" aria-required="true" type="date" />
+                <span asp-validation-for="Applicant.DateOfBirth" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <span class="text-danger">*</span>
@@ -49,15 +45,19 @@
                 <span asp-validation-for="Applicant.Gender" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <span class="text-danger">*</span>
-                <label asp-for="Applicant.DateOfBirth" class="control-label"></label>
-                <input asp-for="Applicant.DateOfBirth" class="form-control" aria-required="true" type="date" />
-                <span asp-validation-for="Applicant.DateOfBirth" class="text-danger"></span>
-            </div>
-            <div class="form-group">
                 <label asp-for="Applicant.BirthPlace" class="control-label"></label>
                 <input asp-for="Applicant.BirthPlace" class="form-control" />
                 <span asp-validation-for="Applicant.BirthPlace" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Applicant.BirthLastName" class="control-label"></label>
+                <input asp-for="Applicant.BirthLastName" class="form-control" />
+                <span asp-validation-for="Applicant.BirthLastName" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Applicant.MothersLastName" class="control-label"></label>
+                <input asp-for="Applicant.MothersLastName" class="form-control" />
+                <span asp-validation-for="Applicant.MothersLastName" class="text-danger"></span>
             </div>
             <div class="form-group mt-3">
                 <button type="submit" class="btn btn-primary btn-sm">

--- a/GardaVettingSystem/Pages/Applicants/Details.cshtml
+++ b/GardaVettingSystem/Pages/Applicants/Details.cshtml
@@ -29,6 +29,24 @@
             @Html.DisplayFor(model => model.Applicant.LastName)
         </dd>
         <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.Applicant.DateOfBirth):
+        </dt>
+        <dd class="col-sm-10">
+            @Model.Applicant.DateOfBirth?.ToString("d")
+        </dd>
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.Applicant.Gender):
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.Applicant.Gender)
+        </dd>
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.Applicant.BirthPlace):
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.Applicant.BirthPlace)
+        </dd>
+        <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.Applicant.BirthLastName):
         </dt>
         <dd class="col-sm-10">
@@ -39,24 +57,6 @@
         </dt>
         <dd class="col-sm-10">
             @Html.DisplayFor(model => model.Applicant.MothersLastName)
-        </dd>
-        <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.Applicant.Gender):
-        </dt>
-        <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.Applicant.Gender)
-        </dd>
-        <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.Applicant.DateOfBirth):
-        </dt>
-        <dd class="col-sm-10">
-            @Model.Applicant.DateOfBirth?.ToString("d")
-        </dd>
-        <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.Applicant.BirthPlace):
-        </dt>
-        <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.Applicant.BirthPlace)
         </dd>
     </dl>
 </div>

--- a/GardaVettingSystem/Pages/Applicants/Details.cshtml.cs
+++ b/GardaVettingSystem/Pages/Applicants/Details.cshtml.cs
@@ -20,19 +20,16 @@ namespace GardaVettingSystem.Pages.Applicants
     {
         private readonly GardaVettingSystemDbContext _context;
         private readonly UserManager<IdentityUser> _userManager;
-        private readonly VettingPdfService _pdfService;
 
         /// <summary>
         /// Initialises a new instance of <see cref="DetailsModel"/> with the required services.
         /// </summary>
         /// <param name="context">The database context.</param>
         /// <param name="userManager">The ASP.NET Identity user manager.</param>
-        /// <param name="pdfService">The PDF generation service.</param>
-        public DetailsModel(GardaVettingSystemDbContext context, UserManager<IdentityUser> userManager, VettingPdfService pdfService)
+        public DetailsModel(GardaVettingSystemDbContext context, UserManager<IdentityUser> userManager)
         {
             _context = context;
             _userManager = userManager;
-            _pdfService = pdfService;
         }
 
         /// <summary>
@@ -92,7 +89,7 @@ namespace GardaVettingSystem.Pages.Applicants
             if (applicant == null)
                 return RedirectToPage("/Applicants/Create");
 
-            var pdf = _pdfService.GeneratePdf(applicant);
+            var pdf = VettingPdfService.GeneratePdf(applicant);
             var fileName = $"{DateTimeOffset.UtcNow:yyyyMMdd}_VettingProfile_{applicant.FullName.Replace(" ", "_", StringComparison.OrdinalIgnoreCase)}.pdf";
 
             return File(pdf, "application/pdf", fileName);

--- a/GardaVettingSystem/Pages/Applicants/Edit.cshtml
+++ b/GardaVettingSystem/Pages/Applicants/Edit.cshtml
@@ -27,14 +27,10 @@
                 <span asp-validation-for="Applicant.LastName" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Applicant.BirthLastName" class="control-label"></label>:
-                <input asp-for="Applicant.BirthLastName" class="form-control" />
-                <span asp-validation-for="Applicant.BirthLastName" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="Applicant.MothersLastName" class="control-label"></label>:
-                <input asp-for="Applicant.MothersLastName" class="form-control" />
-                <span asp-validation-for="Applicant.MothersLastName" class="text-danger"></span>
+                <span class="text-danger">*</span>
+                <label asp-for="Applicant.DateOfBirth" class="control-label"></label>:
+                <input asp-for="Applicant.DateOfBirth" class="form-control" aria-required="true" value="@Model.Applicant.DateOfBirth?.ToString("yyyy-MM-dd")" type="date" />
+                <span asp-validation-for="Applicant.DateOfBirth" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <span class="text-danger">*</span>
@@ -50,15 +46,19 @@
                 <span asp-validation-for="Applicant.Gender" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <span class="text-danger">*</span>
-                <label asp-for="Applicant.DateOfBirth" class="control-label"></label>:
-                <input asp-for="Applicant.DateOfBirth" class="form-control" aria-required="true" value="@Model.Applicant.DateOfBirth?.ToString("yyyy-MM-dd")" type="date" />
-                <span asp-validation-for="Applicant.DateOfBirth" class="text-danger"></span>
-            </div>
-            <div class="form-group">
                 <label asp-for="Applicant.BirthPlace" class="control-label"></label>:
                 <input asp-for="Applicant.BirthPlace" class="form-control" />
                 <span asp-validation-for="Applicant.BirthPlace" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Applicant.BirthLastName" class="control-label"></label>:
+                <input asp-for="Applicant.BirthLastName" class="form-control" />
+                <span asp-validation-for="Applicant.BirthLastName" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Applicant.MothersLastName" class="control-label"></label>:
+                <input asp-for="Applicant.MothersLastName" class="form-control" />
+                <span asp-validation-for="Applicant.MothersLastName" class="text-danger"></span>
             </div>
             <div class="form-group mt-3">
                 <button type="submit" class="btn btn-primary btn-sm">

--- a/GardaVettingSystem/Program.cs
+++ b/GardaVettingSystem/Program.cs
@@ -15,7 +15,6 @@ builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 builder.Services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = false)
     .AddEntityFrameworkStores<GardaVettingSystemDbContext>();
 builder.Services.AddRazorPages();
-builder.Services.AddScoped<VettingPdfService>();
 
 var app = builder.Build();
 

--- a/GardaVettingSystem/Services/VettingPdfService.cs
+++ b/GardaVettingSystem/Services/VettingPdfService.cs
@@ -11,14 +11,20 @@ namespace GardaVettingSystem.Services
     /// Used to provide a downloadable export of profile data for organisations
     /// that cannot access the system directly.
     /// </summary>
-    public class VettingPdfService
+    public sealed class VettingPdfService
     {
+
+        /// <summary>
+        /// Protected constructor — prevents external instantiation.
+        /// </summary>
+        private VettingPdfService() { }
+
         /// <summary>
         /// Generates a PDF document for the given applicant profile.
         /// </summary>
         /// <param name="applicant">The applicant profile including address history.</param>
         /// <returns>A byte array containing the generated PDF.</returns>
-        public byte[] GeneratePdf(Applicant applicant)
+        public static byte[] GeneratePdf(Applicant applicant)
         {
             QuestPDF.Settings.License = LicenseType.Community;
 
@@ -30,78 +36,8 @@ namespace GardaVettingSystem.Services
                     page.Margin(2, Unit.Centimetre);
                     page.DefaultTextStyle(x => x.FontSize(11));
 
-                    page.Header().Column(col =>
-                    {
-                        col.Item().Text("Garda Vetting Data Reuse System")
-                            .FontSize(18).Bold();
-                        col.Item().Text("Applicant Vetting Profile")
-                            .FontSize(13).FontColor(Colors.Grey.Darken2);
-                        col.Item().PaddingTop(5).LineHorizontal(1);
-                    });
-
-                    page.Content().PaddingTop(20).Column(col =>
-                    {
-                        // Personal Details
-                        col.Item().Text("Personal Details").FontSize(13).Bold();
-                        col.Item().PaddingTop(5).Table(table =>
-                        {
-                            table.ColumnsDefinition(columns =>
-                            {
-                                columns.RelativeColumn(2);
-                                columns.RelativeColumn(3);
-                            });
-
-                            AddRow(table, "Full Name", applicant.FullName);
-                            AddRow(table, "Date of Birth", applicant.DateOfBirth?.ToString("d", CultureInfo.InvariantCulture) ?? string.Empty);
-                            AddRow(table, "Gender", applicant.Gender);
-                            AddRow(table, "Place of Birth", applicant.BirthPlace);
-                            AddRow(table, "Surname at Birth", applicant.BirthLastName);
-                            AddRow(table, "Mother's Last Name", applicant.MothersLastName);
-                        });
-
-                        // Address History
-                        col.Item().PaddingTop(20).Text("Address History").FontSize(13).Bold();
-
-                        if (applicant.ApplicantAddresses != null && applicant.ApplicantAddresses.Count > 0)
-                        {
-                            col.Item().PaddingTop(5).Table(table =>
-                            {
-                                table.ColumnsDefinition(columns =>
-                                {
-                                    columns.RelativeColumn(4);
-                                    columns.RelativeColumn(2);
-                                    columns.RelativeColumn(2);
-                                    columns.RelativeColumn(1);
-                                    columns.RelativeColumn(1);
-                                });
-
-                                // Header row
-                                table.Header(header =>
-                                {
-                                    header.Cell().Background(Colors.Grey.Lighten2).Padding(5).Text("Address").Bold();
-                                    header.Cell().Background(Colors.Grey.Lighten2).Padding(5).Text("Postcode").Bold();
-                                    header.Cell().Background(Colors.Grey.Lighten2).Padding(5).Text("Country").Bold();
-                                    header.Cell().Background(Colors.Grey.Lighten2).Padding(5).Text("From").Bold();
-                                    header.Cell().Background(Colors.Grey.Lighten2).Padding(5).Text("To").Bold();
-                                });
-
-                                foreach (var address in applicant.ApplicantAddresses)
-                                {
-                                    table.Cell().Padding(5).Text(address.AddressLine);
-                                    table.Cell().Padding(5).Text(address.Postcode);
-                                    table.Cell().Padding(5).Text(address.Country);
-                                    table.Cell().Padding(5).Text(address.ResidentFrom?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
-                                    table.Cell().Padding(5).Text(address.ResidentTo.HasValue ? address.ResidentTo.Value.ToString(CultureInfo.InvariantCulture)! : "Current");
-                                }
-                            });
-                        }
-                        else
-                        {
-                            col.Item().PaddingTop(5).Text("No address history available.")
-                                .FontColor(Colors.Grey.Darken1);
-                        }
-                    });
-
+                    page.Header().Column(col => AddHeader(col));
+                    page.Content().PaddingTop(20).Column(col => AddContent(col, applicant));
                     page.Footer().AlignCenter().Text(text =>
                     {
                         text.Span("Generated by Garda Vetting Data Reuse System — ");
@@ -112,8 +48,100 @@ namespace GardaVettingSystem.Services
         }
 
         /// <summary>
+        /// Adds the document header section.
+        /// </summary>
+        /// <param name="col">The column descriptor to add the header to.</param>
+        private static void AddHeader(ColumnDescriptor col)
+        {
+            col.Item().Text("Garda Vetting Data Reuse System").FontSize(18).Bold();
+            col.Item().Text("Applicant Vetting Profile").FontSize(13).FontColor(Colors.Grey.Darken2);
+            col.Item().PaddingTop(5).LineHorizontal(1);
+        }
+
+        /// <summary>
+        /// Adds the main content section including personal details and address history.
+        /// </summary>
+        /// <param name="col">The column descriptor to add content to.</param>
+        /// <param name="applicant">The applicant profile to render.</param>
+        private static void AddContent(ColumnDescriptor col, Applicant applicant)
+        {
+            col.Item().Text("Personal Details").FontSize(13).Bold();
+            col.Item().PaddingTop(5).Table(table => AddPersonalDetailsTable(table, applicant));
+
+            col.Item().PaddingTop(20).Text("Address History").FontSize(13).Bold();
+
+            if (applicant.ApplicantAddresses != null && applicant.ApplicantAddresses.Count > 0)
+            {
+                col.Item().PaddingTop(5).Table(table => AddAddressTable(table, applicant.ApplicantAddresses));
+            }
+            else
+            {
+                col.Item().PaddingTop(5).Text("No address history available.").FontColor(Colors.Grey.Darken1);
+            }
+        }
+
+        /// <summary>
+        /// Adds the personal details table to the document.
+        /// </summary>
+        /// <param name="table">The table descriptor to populate.</param>
+        /// <param name="applicant">The applicant whose details to render.</param>
+        private static void AddPersonalDetailsTable(TableDescriptor table, Applicant applicant)
+        {
+            table.ColumnsDefinition(columns =>
+            {
+                columns.RelativeColumn(2);
+                columns.RelativeColumn(3);
+            });
+
+            AddRow(table, "Full Name", applicant.FullName);
+            AddRow(table, "Date of Birth", applicant.DateOfBirth?.ToString("d", CultureInfo.InvariantCulture) ?? string.Empty);
+            AddRow(table, "Gender", applicant.Gender);
+            AddRow(table, "Place of Birth", applicant.BirthPlace);
+            AddRow(table, "Surname at Birth", applicant.BirthLastName);
+            AddRow(table, "Mother's Last Name", applicant.MothersLastName);
+        }
+
+        /// <summary>
+        /// Adds the address history table to the document.
+        /// </summary>
+        /// <param name="table">The table descriptor to populate.</param>
+        /// <param name="addresses">The collection of addresses to render.</param>
+        private static void AddAddressTable(TableDescriptor table, ICollection<ApplicantAddress> addresses)
+        {
+            table.ColumnsDefinition(columns =>
+            {
+                columns.RelativeColumn(4);
+                columns.RelativeColumn(2);
+                columns.RelativeColumn(2);
+                columns.RelativeColumn(1);
+                columns.RelativeColumn(1);
+            });
+
+            table.Header(header =>
+            {
+                header.Cell().Background(Colors.Grey.Lighten2).Padding(5).Text("Address").Bold();
+                header.Cell().Background(Colors.Grey.Lighten2).Padding(5).Text("Postcode").Bold();
+                header.Cell().Background(Colors.Grey.Lighten2).Padding(5).Text("Country").Bold();
+                header.Cell().Background(Colors.Grey.Lighten2).Padding(5).Text("From").Bold();
+                header.Cell().Background(Colors.Grey.Lighten2).Padding(5).Text("To").Bold();
+            });
+
+            foreach (var address in addresses)
+            {
+                table.Cell().Padding(5).Text(address.AddressLine);
+                table.Cell().Padding(5).Text(address.Postcode);
+                table.Cell().Padding(5).Text(address.Country);
+                table.Cell().Padding(5).Text(address.ResidentFrom?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+                table.Cell().Padding(5).Text(address.ResidentTo.HasValue ? address.ResidentTo.Value.ToString(CultureInfo.InvariantCulture) : "Current");
+            }
+        }
+
+        /// <summary>
         /// Adds a label/value row to a two-column table.
         /// </summary>
+        /// <param name="table">The table descriptor to add the row to.</param>
+        /// <param name="label">The label text.</param>
+        /// <param name="value">The value text.</param>
         private static void AddRow(TableDescriptor table, string label, string value)
         {
             table.Cell().Padding(4).Text(label).Bold();


### PR DESCRIPTION
## Summary
Resolves SonarQube warnings on VettingPdfService and standardises field order across all Applicant pages and the PDF export.

## Changes
- Updated:
  - VettingPdfService — refactored to reduce cognitive complexity, added sealed class and private constructor to satisfy CA1052
  - Field order standardised across Create, Edit, Details and PDF to match logical vetting document order
  - Removed DI registration for VettingPdfService — now called statically

## Type of Change
- [x] Refactor

## Testing
- [x] All existing NUnit tests passing
- [x] Manually tested — PDF export, field order consistent across all pages

## Impact
- Modules: Applicants, Services
- Database: No changes

## Breaking Changes
- [x] No

## Related
- Milestone: Implementation Chapter — 3 May 2026
- Branch: feature/pdf-export
