### PR TITLE
chore: default pages consistency pass and README update

### DIFF
--- a/GardaVettingSystem/Pages/Error.cshtml
+++ b/GardaVettingSystem/Pages/Error.cshtml
@@ -4,8 +4,9 @@
     ViewData["Title"] = "Error";
 }
 
-<h1 class="text-danger">Error.</h1>
-<h2 class="text-danger">An error occurred while processing your request.</h2>
+<h1 class="text-danger">Something went wrong.</h1>
+<hr />
+<p>An unexpected error occurred while processing your request.</p>
 
 @if (Model.ShowRequestId)
 {
@@ -14,13 +15,6 @@
     </p>
 }
 
-<h3>Development Mode</h3>
-<p>
-    Swapping to the <strong>Development</strong> environment displays detailed information about the error that occurred.
-</p>
-<p>
-    <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
-    It can result in displaying sensitive information from exceptions to end users.
-    For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
-    and restarting the app.
-</p>
+<a asp-page="/Index" class="btn btn-secondary btn-sm">
+    <i class="bi bi-house-fill"></i> Back to Home
+</a>

--- a/GardaVettingSystem/Pages/Index.cshtml
+++ b/GardaVettingSystem/Pages/Index.cshtml
@@ -1,10 +1,10 @@
 ﻿@page
 @model IndexModel
 @{
-    ViewData["Title"] = "Home page";
+    ViewData["Title"] = "Home";
 }
 
 <div class="text-center">
-    <h1 class="display-4">Welcome</h1>
-    <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+    <h1 class="display-4">Garda Vetting System</h1>
+    <p class="lead">A secure platform for Irish volunteers to store and share Garda vetting information across organisations.</p>
 </div>

--- a/GardaVettingSystem/Pages/Privacy.cshtml
+++ b/GardaVettingSystem/Pages/Privacy.cshtml
@@ -4,7 +4,7 @@
     ViewData["Title"] = "Student Info";
 }
 <h1>@ViewData["Title"]</h1>
-
+<hr />
 <p>This application was developed as part of a college project.</p>
 
 <table class="table table-bordered w-50">

--- a/GardaVettingSystem/Pages/Shared/_Layout.cshtml
+++ b/GardaVettingSystem/Pages/Shared/_Layout.cshtml
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>@ViewData["Title"] - GardaVettingSystem</title>
+    <title>@ViewData["Title"] - Garda Vetting System</title>
     <script type="importmap"></script>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
@@ -14,7 +14,7 @@
     <header>
         <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
             <div class="container">
-                <a class="navbar-brand" asp-area="" asp-page="/Index">GardaVettingSystem</a>
+                <a class="navbar-brand" asp-area="" asp-page="/Index">Garda Vetting System</a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
                         aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
@@ -41,7 +41,7 @@
 
     <footer class="border-top footer text-muted">
         <div class="container">
-            &copy; 2026 - GardaVettingSystem - <a asp-area="" asp-page="/Privacy">Student Info</a>
+            &copy; 2026 - Garda Vetting System - <a asp-area="" asp-page="/Privacy">Student Info</a>
         </div>
     </footer>
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ This project is a college project developed as part of the the Project Module at
 - ✅ Post-deletion confirmation flow with option to fully delete Identity account
 - ✅ ResidentFrom made nullable with database migration
 - ✅ Clipboard copy button for access codes
+- ✅ PDF export — applicant profile downloadable as PDF
+- ✅ Default pages updated for consistency (Index, Privacy, Error, Layout)
 
 ### In Progress
 - 🔄 Implementation Chapter writeup — deadline 3 May 2026


### PR DESCRIPTION
## Summary
Updated default scaffold pages for consistency with the rest of the application and updated the README.

## Context
- Default ASP.NET scaffold pages still had boilerplate content
- Footer had the unstyled Visual Studio project name
- README needed updating to reflect recently completed work

## Changes
- Added: `<hr />` to `Privacy.cshtml`
- Updated: `Index.cshtml` with project landing page content
- Updated: `Error.cshtml` with a user-friendly error message and Back to Home button
- Updated: `_Layout.cshtml` footer — `GardaVettingSystem` corrected to `Garda Vetting System`
- Updated: `README.md` — PDF export and default pages consistency pass added to completed list

## Type of Change
- [x] Documentation

## Testing
- [x] Manually tested

**Test Details:**
Visually verified all updated pages render correctly.

## Impact
- UI: Landing page, error page, student info page, site footer

## Breaking Changes
- [x] No

## Related
- Branch: chore/default-pages-consistency