### PR TITLE
feat: add public validate access and privacy notice

### DIFF
--- a/GardaVettingSystem/Pages/Index.cshtml
+++ b/GardaVettingSystem/Pages/Index.cshtml
@@ -7,4 +7,7 @@
 <div class="text-center">
     <h1 class="display-4">Garda Vetting System</h1>
     <p class="lead">A secure platform for Irish volunteers to store and share Garda vetting information across organisations.</p>
+    <a asp-page="/AccessCodes/Validate" class="btn btn-primary btn-sm">
+        <i class="bi bi-search"></i> Validate Access Code
+    </a>
 </div>

--- a/GardaVettingSystem/Pages/Privacy.cshtml
+++ b/GardaVettingSystem/Pages/Privacy.cshtml
@@ -1,31 +1,29 @@
 ﻿@page
 @model PrivacyModel
 @{
-    ViewData["Title"] = "Student Info";
+    ViewData["Title"] = "Privacy";
 }
 <h1>@ViewData["Title"]</h1>
-<hr />
-<p>This application was developed as part of a college project.</p>
 
-<table class="table table-bordered w-50">
-    <tr>
-        <th>Student Name:</th>
-        <td>Ann Marie Dunne</td>
-    </tr>
-    <tr>
-        <th>Student ID:</th>
-        <td>L00196623</td>
-    </tr>
-    <tr>
-        <th>Student Email:</th>
-        <td>L00196623@atu.ie</td>
-    </tr>
-    <tr>
-        <th>Module:</th>
-        <td>Project (2025/26)</td>
-    </tr>
-    <tr>
-        <th>Module Code:</th>
-        <td>PROJ_IT805 - LYICSWDB</td>
-    </tr>
-</table>
+<hr />
+
+<p>The Garda Vetting System is committed to protecting your personal data in accordance with the General Data Protection Regulation (GDPR) and the Data Protection Act 2018.</p>
+
+<h4>What Data We Collect</h4>
+<p>The system collects personal information required for Garda vetting purposes, including your name, date of birth, gender, place of birth, and address history.</p>
+
+<h4>Why We Collect It</h4>
+<p>Your data is collected solely to enable you to share verified vetting information with organisations that require it, reducing the need to repeat the vetting process.</p>
+
+<h4>Data Retention</h4>
+<p>Your data is retained for as long as you maintain an account.</p>
+
+<h4>Your Right to Delete</h4>
+<p>You have the right to erasure under GDPR. This can be done from your profile page. Deleting your profile will permanently remove your personal data from the system.</p>
+
+<h4>Access Codes</h4>
+<p>Access codes you generate are time-limited and can be revoked at any time. Revoked codes cannot be used to access your data.</p>
+
+<h4>Data Sharing</h4>
+<p>Your data is never shared with third parties. It is only made available to an organisation when you explicitly generate and share an access code with them.</p>
+

--- a/GardaVettingSystem/Pages/Shared/_Layout.cshtml
+++ b/GardaVettingSystem/Pages/Shared/_Layout.cshtml
@@ -25,7 +25,10 @@
                             <a class="nav-link text-dark" asp-area="" asp-page="/Index">Home</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-page="/Privacy">Student Info</a>
+                            <a class="nav-link text-dark" asp-area="" asp-page="/AccessCodes/Validate">Validate</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-page="/Privacy">Privacy</a>
                         </li>
                     </ul>
                     <partial name="_LoginPartial" />
@@ -41,7 +44,7 @@
 
     <footer class="border-top footer text-muted">
         <div class="container">
-            &copy; 2026 - Garda Vetting System - <a asp-area="" asp-page="/Privacy">Student Info</a>
+            &copy; 2026 - Garda Vetting System - <a asp-area="" asp-page="/Privacy">Privacy</a>
         </div>
     </footer>
 


### PR DESCRIPTION
## Summary
Added public access to the Validate Access Code page and repurposed the Privacy page as a GDPR-aware Privacy Notice.

## Context
- The Validate Access Code page was not reachable without logging in, breaking the round trip for organisations
- The Privacy page was being used as a Student Info page which was not appropriate for a running application
- A proper Privacy Notice is relevant given GDPR is central to this project

## Changes
- Added: Validate Access Code button to `Index.cshtml` landing page
- Added: Validate nav link to `_Layout.cshtml` navbar
- Updated: `_Layout.cshtml` — Student Info renamed to Privacy throughout
- Updated: `Privacy.cshtml` — repurposed as a GDPR Privacy Notice covering data collection, retention, right to delete, access codes and data sharing

## Type of Change
- [x] New feature
- [x] Documentation

## Testing
- [x] Manually tested

**Test Details:**
Verified Validate page is reachable from the landing page without logging in. 
Verified Privacy Notice renders correctly.

## Impact
- UI: Landing page, navbar, privacy page

## Breaking Changes
- [x] No

## Related
- Milestone: Implementation Chapter — 3 May 2026
- Branch: feature/validate-public-access

