### PR TITLE
fix: edit tracking conflict, unused usings and login display name

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -32,6 +32,7 @@ csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
 dotnet_diagnostic.CA1515.severity = none
 dotnet_diagnostic.CA2007.severity = none
+dotnet_diagnostic.IDE0005.severity = warning
 
 # Indentation preferences
 csharp_indent_block_contents = true
@@ -207,3 +208,4 @@ end_of_line = crlf
 dotnet_diagnostic.CS1591.severity = none
 dotnet_diagnostic.CA1515.severity = none
 dotnet_diagnostic.CA1062.severity = none
+dotnet_diagnostic.IDE0005.severity = none

--- a/GardaVettingSystem/Pages/AccessCodes/Validate.cshtml.cs
+++ b/GardaVettingSystem/Pages/AccessCodes/Validate.cshtml.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using GardaVettingSystem.Data;
 using GardaVettingSystem.Models;

--- a/GardaVettingSystem/Pages/ApplicantAddresses/Edit.cshtml.cs
+++ b/GardaVettingSystem/Pages/ApplicantAddresses/Edit.cshtml.cs
@@ -104,7 +104,11 @@ namespace GardaVettingSystem.Pages.ApplicantAddresses
             if (!ModelState.IsValid)
                 return Page();
 
-            _context.Attach(ApplicantAddress).State = EntityState.Modified;
+            existing.AddressLine = ApplicantAddress.AddressLine;
+            existing.Postcode = ApplicantAddress.Postcode;
+            existing.Country = ApplicantAddress.Country;
+            existing.ResidentFrom = ApplicantAddress.ResidentFrom;
+            existing.ResidentTo = ApplicantAddress.ResidentTo;
 
             try
             {

--- a/GardaVettingSystem/Pages/Applicants/Edit.cshtml.cs
+++ b/GardaVettingSystem/Pages/Applicants/Edit.cshtml.cs
@@ -94,7 +94,13 @@ namespace GardaVettingSystem.Pages.Applicants
                 return Page();
             }
 
-            _context.Attach(Applicant).State = EntityState.Modified;
+            existing.FirstName = Applicant.FirstName;
+            existing.LastName = Applicant.LastName;
+            existing.DateOfBirth = Applicant.DateOfBirth;
+            existing.Gender = Applicant.Gender;
+            existing.BirthPlace = Applicant.BirthPlace;
+            existing.BirthLastName = Applicant.BirthLastName;
+            existing.MothersLastName = Applicant.MothersLastName;
 
             try
             {

--- a/GardaVettingSystem/Pages/Index.cshtml.cs
+++ b/GardaVettingSystem/Pages/Index.cshtml.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using GardaVettingSystem.Data;
 using GardaVettingSystem.Models;

--- a/GardaVettingSystem/Pages/Privacy.cshtml.cs
+++ b/GardaVettingSystem/Pages/Privacy.cshtml.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
+﻿using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace GardaVettingSystem.Pages
 {
@@ -13,6 +12,7 @@ namespace GardaVettingSystem.Pages
         /// </summary>
         public void OnGet()
         {
+            // Intentionally empty — no data is required to render this page.
         }
     }
 

--- a/GardaVettingSystem/Pages/Shared/_LoginPartial.cshtml
+++ b/GardaVettingSystem/Pages/Shared/_LoginPartial.cshtml
@@ -1,16 +1,22 @@
 ﻿@using Microsoft.AspNetCore.Identity
+@using Microsoft.EntityFrameworkCore
+@using GardaVettingSystem.Data
 @inject SignInManager<IdentityUser> SignInManager
 @inject UserManager<IdentityUser> UserManager
+@inject GardaVettingSystemDbContext DbContext
 
 <ul class="navbar-nav">
 @if (SignInManager.IsSignedIn(User))
 {
+    var userId = UserManager.GetUserId(User);
+    var applicant = await DbContext.Applicants.FirstOrDefaultAsync(a => a.UserId == userId);
+    var displayName = applicant != null ? applicant.FirstName : User.Identity?.Name;
     <li class="nav-item">
-        <a  class="nav-link text-dark" asp-area="Identity" asp-page="/Account/Manage/Index" title="Manage">Hello @User.Identity?.Name!</a>
+        <a class="nav-link text-dark" asp-area="Identity" asp-page="/Account/Manage/Index" title="Manage">Hello @displayName</a>
     </li>
     <li class="nav-item">
         <form class="form-inline" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Page("/Index", new { area = "" })">
-            <button  type="submit" class="nav-link btn btn-link text-dark">Logout</button>
+            <button type="submit" class="nav-link btn btn-link text-dark">Logout</button>
         </form>
     </li>
 }

--- a/GardaVettingSystem/Program.cs
+++ b/GardaVettingSystem/Program.cs
@@ -1,5 +1,4 @@
 using GardaVettingSystem.Data;
-using GardaVettingSystem.Services;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
@@ -11,7 +10,7 @@ builder.Services.AddDbContext<GardaVettingSystemDbContext>(options =>
     options.UseSqlServer(connectionString));
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 
-// TODO: Re-enable this back to true
+// Email confirmation is not required — no email provider is configured for this project.
 builder.Services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = false)
     .AddEntityFrameworkStores<GardaVettingSystemDbContext>();
 builder.Services.AddRazorPages();


### PR DESCRIPTION
## Summary
Fixed an EF Core tracking conflict on edit pages, removed unused usings, and improved the navbar display name for logged-in users.

## Context
- Editing an applicant or address was throwing an InvalidOperationException due to EF Core tracking two instances of the same entity
- Unused using directives were present in several files
- The navbar was displaying the user's email address instead of their first name

## Changes
- Updated: `Applicants/Edit.cshtml.cs` — fixed EF Core tracking conflict by updating existing tracked entity
- Updated: `ApplicantAddresses/Edit.cshtml.cs` — same tracking conflict fix
- Updated: `_LoginPartial.cshtml` — displays applicant first name, falls back to email if no profile exists
- Updated: `Program.cs` — removed TODO comment and unused using for Services
- Updated: `Validate.cshtml.cs`, `Privacy.cshtml.cs`, `Index.cshtml.cs` — removed unused usings
- Updated: `.editorconfig` — added IDE0005 warning rule for unused usings

## Type of Change
- [x] Bug fix

## Testing
- [x] All existing NUnit tests passing
- [x] Manually tested

**Test Details:**
Verified edit applicant and edit address both save correctly without throwing. Verified navbar displays first name for users with a profile and falls back to email for new users.

## Impact
- UI: Navbar display name
- Modules: Applicants/Edit, ApplicantAddresses/Edit

## Breaking Changes
- [x] No

## Related
- Branch: fix/edit-tracking-conflict
